### PR TITLE
Fix mocking for DateOnly and improve realtime service

### DIFF
--- a/src/shared/application/use-cases/__tests__/CreateSystemLogUseCase.test.ts
+++ b/src/shared/application/use-cases/__tests__/CreateSystemLogUseCase.test.ts
@@ -4,20 +4,25 @@ import { TodoDatabase, TaskLogRecord } from '../../../infrastructure/database/To
 import { TaskId } from '../../../domain/value-objects/TaskId';
 import { TaskCategory } from '../../../domain/types';
 import { ResultUtils } from '../../../domain/Result';
+import { DebouncedSyncService } from '../../services/DebouncedSyncService';
 
 // Mock database
 const mockDatabase = {
   taskLogs: {
-    add: vi.fn()
-  }
+    add: vi.fn(),
+  },
 } as unknown as TodoDatabase;
+
+const mockSyncService = {
+  triggerSync: vi.fn(),
+} as unknown as DebouncedSyncService;
 
 describe('CreateSystemLogUseCase', () => {
   let useCase: CreateSystemLogUseCase;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    useCase = new CreateSystemLogUseCase(mockDatabase);
+    useCase = new CreateSystemLogUseCase(mockDatabase, mockSyncService);
   });
 
   describe('execute', () => {


### PR DESCRIPTION
## Summary
- provide class-preserving mock for `DateOnly` in test setup
- fix `CreateSystemLogUseCase` tests by mocking sync service dependency
- add event emitter to `SupabaseRealtimeService` and correct daily selection change handling

## Testing
- `npm test src/shared/domain/value-objects/__tests__/DateOnly.test.ts`
- `npm test src/shared/application/use-cases/__tests__/CreateSystemLogUseCase.test.ts`
- `npm test src/shared/infrastructure/sync/__tests__/SupabaseRealtimeService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f2fa4720c83338c218c98006ba70d