### PR TITLE
Show task text and last log in drag preview

### DIFF
--- a/src/features/tasks/presentation/components/TaskList.tsx
+++ b/src/features/tasks/presentation/components/TaskList.tsx
@@ -305,25 +305,19 @@ export const TaskList: React.FC<TaskListProps> = ({
         <DragOverlay modifiers={[applyDragOffset, restrictToWindowEdges]}>
           {activeTask ? (
             <motion.div
-              className="bg-white rounded-lg border-2 border-blue-300 shadow-lg p-2 max-w-xs"
+              className="bg-white rounded-lg border-2 border-blue-300 shadow-lg p-2 max-w-[240px] text-sm"
               initial={{ scale: 0.8, opacity: 0.8 }}
               animate={{ scale: 1, opacity: 1 }}
-              style={{
-                width: "32px",
-                height: "32px",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: "12px",
-                fontWeight: "bold",
-                color: "#374151",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
               data-testid="drag-overlay"
             >
-              {activeTask.title.value}
+              <p className="font-medium text-gray-800 truncate">
+                {activeTask.title.value}
+              </p>
+              {lastLogs[activeTask.id.value] && (
+                <p className="mt-1 text-xs text-gray-500 truncate">
+                  {lastLogs[activeTask.id.value].message}
+                </p>
+              )}
             </motion.div>
           ) : null}
         </DragOverlay>

--- a/tests/drag-and-drop.spec.ts
+++ b/tests/drag-and-drop.spec.ts
@@ -7,40 +7,39 @@ test.describe('Drag and Drop Functionality', () => {
     await page.waitForSelector('[data-testid="task-list"], .text-center', { timeout: 10000 });
   });
 
-  test('should display miniature task card during drag', async ({ page }) => {
-    // Check if there are tasks available
+  test('should display compact task preview during drag', async ({ page }) => {
     const taskCards = await page.locator('[data-testid="task-card"]').count();
-    
+
     if (taskCards === 0) {
-      // Create a test task first
       await page.click('button:has-text("New Task")');
       await page.fill('input[placeholder*="task"]', 'Test Drag Task');
       await page.press('input[placeholder*="task"]', 'Enter');
       await page.waitForSelector('[data-testid="task-card"]');
     }
 
-    // Get the first task card
     const firstTask = page.locator('[data-testid="task-card"]').first();
     await expect(firstTask).toBeVisible();
 
-    // Start dragging
+    const title = await firstTask.locator('h3').textContent();
+
     const taskBounds = await firstTask.boundingBox();
     if (taskBounds) {
-      await page.mouse.move(taskBounds.x + taskBounds.width / 2, taskBounds.y + taskBounds.height / 2);
+      await page.mouse.move(
+        taskBounds.x + taskBounds.width / 2,
+        taskBounds.y + taskBounds.height / 2
+      );
       await page.mouse.down();
-      
-      // Move mouse to trigger drag
-      await page.mouse.move(taskBounds.x + taskBounds.width / 2, taskBounds.y + taskBounds.height / 2 + 50);
-      
-      // Check if miniature card appears (should be 32px height)
-      const dragOverlay = page.locator('[data-testid="drag-overlay"], .transform-gpu');
+      await page.mouse.move(
+        taskBounds.x + taskBounds.width / 2,
+        taskBounds.y + taskBounds.height / 2 + 50
+      );
+
+      const dragOverlay = page.locator('[data-testid="drag-overlay"]');
       await expect(dragOverlay).toBeVisible();
-      
-      // Verify the miniature card has correct styling
-      const miniatureCard = dragOverlay.locator('div').first();
-      await expect(miniatureCard).toHaveClass(/h-8/);
-      
-      // End drag
+      if (title) {
+        await expect(dragOverlay).toContainText(title.trim());
+      }
+
       await page.mouse.up();
     }
   });


### PR DESCRIPTION
## Summary
- Render a compact drag preview card displaying task title and its last log
- Adjust E2E drag preview test for new overlay content

## Testing
- `npm test` (fails: DataError and other warnings)
- `npx playwright test tests/drag-and-drop.spec.ts --project=chromium` (fails: browser executable missing)


------
https://chatgpt.com/codex/tasks/task_e_688f3003056c8333b1c41aceb9d1db11