### PR TITLE
feat: add trash view for deleted tasks

### DIFF
--- a/src/features/trash/presentation/components/TrashView.tsx
+++ b/src/features/trash/presentation/components/TrashView.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from "react";
+import { TrashViewModel } from "../view-models/TrashViewModel";
+import { Button } from "../../../shared/ui/button";
+
+interface TrashViewProps {
+  viewModel: TrashViewModel;
+}
+
+export const TrashView: React.FC<TrashViewProps> = ({ viewModel }) => {
+  const { tasks, loadTasks, clearTrash, loading, error } = viewModel();
+
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
+
+  return (
+    <div className="space-y-4">
+      {error && <div className="text-red-500">{error}</div>}
+      {tasks.length > 0 && (
+        <Button variant="destructive" onClick={clearTrash} data-testid="clear-trash">
+          Очистить корзину
+        </Button>
+      )}
+      {loading && <div>Loading...</div>}
+      <ul className="space-y-2">
+        {tasks.map((task) => (
+          <li key={task.id.value} className="p-2 bg-white rounded shadow">
+            {task.title.value}
+          </li>
+        ))}
+      </ul>
+      {tasks.length === 0 && !loading && (
+        <p className="text-center text-gray-500">Корзина пуста</p>
+      )}
+    </div>
+  );
+};

--- a/src/features/trash/presentation/view-models/TrashViewModel.ts
+++ b/src/features/trash/presentation/view-models/TrashViewModel.ts
@@ -1,0 +1,48 @@
+import { create } from "zustand";
+import { Task } from "../../../../shared/domain/entities/Task";
+import { TaskRepository } from "../../../../shared/domain/repositories/TaskRepository";
+
+export interface TrashViewModelState {
+  tasks: Task[];
+  loading: boolean;
+  error: string | null;
+  loadTasks: () => Promise<void>;
+  clearTrash: () => Promise<void>;
+}
+
+export interface TrashViewModelDependencies {
+  taskRepository: TaskRepository;
+}
+
+export const createTrashViewModel = (
+  deps: TrashViewModelDependencies
+) => {
+  const { taskRepository } = deps;
+  return create<TrashViewModelState>((set) => ({
+    tasks: [],
+    loading: false,
+    error: null,
+    loadTasks: async () => {
+      set({ loading: true, error: null });
+      try {
+        const tasks = await taskRepository.findDeleted();
+        set({ tasks, loading: false });
+      } catch (error) {
+        set({
+          loading: false,
+          error: error instanceof Error ? error.message : "Failed to load tasks",
+        });
+      }
+    },
+    clearTrash: async () => {
+      try {
+        await taskRepository.clearDeleted();
+        set({ tasks: [] });
+      } catch (error) {
+        set({ error: error instanceof Error ? error.message : "Failed to clear" });
+      }
+    },
+  }));
+};
+
+export type TrashViewModel = ReturnType<typeof createTrashViewModel>;

--- a/src/mvp/MVPApp.tsx
+++ b/src/mvp/MVPApp.tsx
@@ -17,6 +17,10 @@ import {
   TodayViewModelDependencies,
   createTodayViewModel,
 } from "../features/today/presentation/view-models/TodayViewModel";
+import {
+  createTrashViewModel,
+  TrashViewModel,
+} from "../features/trash/presentation/view-models/TrashViewModel";
 import { useKeyboardShortcuts } from "../shared/infrastructure/services/useKeyboardShortcuts";
 import { DailyModalContainer } from "../features/onboarding";
 import { useOnboardingViewModel } from "../features/onboarding/presentation/view-models/OnboardingViewModel";
@@ -52,7 +56,7 @@ export const MVPApp: React.FC = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   const [activeView, setActiveView] = useState<
-    "today" | "logs" | "settings" | TaskCategory
+    "today" | "logs" | "settings" | "trash" | TaskCategory
   >("today");
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDbReady, setIsDbReady] = useState(false);
@@ -165,6 +169,10 @@ export const MVPApp: React.FC = () => {
   const todayViewModel = useMemo(
     () => createTodayViewModel(todayDependencies),
     []
+  );
+  const trashViewModel: TrashViewModel = useMemo(
+    () => createTrashViewModel({ taskRepository }),
+    [taskRepository]
   );
 
   // Initialize keyboard shortcuts
@@ -580,7 +588,7 @@ export const MVPApp: React.FC = () => {
   );
 
   const handleViewChange = useCallback(
-    (view: "today" | "logs" | TaskCategory) => {
+    (view: "today" | "logs" | "settings" | "trash" | TaskCategory) => {
       setActiveView(view);
     },
     []
@@ -849,6 +857,7 @@ export const MVPApp: React.FC = () => {
             onCreateTaskLog={handleCreateTaskLog}
             onDeferTask={handleDeferTask}
             onUndeferTask={handleUndeferTask}
+            trashViewModel={trashViewModel}
           />
         </main>
       </div>

--- a/src/mvp/components/ContentArea.tsx
+++ b/src/mvp/components/ContentArea.tsx
@@ -7,11 +7,13 @@ import { AllLogsView } from "../../features/logs/presentation/components";
 import { Settings } from "../../features/settings/presentation/components/Settings";
 import { TodayViewModelDependencies } from "../../features/today/presentation/view-models/TodayViewModel";
 import { LogViewModelDependencies } from "../../features/logs/presentation/view-models/LogViewModel";
+import { TrashView } from "../../features/trash/presentation/components/TrashView";
+import { TrashViewModel } from "../../features/trash/presentation/view-models/TrashViewModel";
 import { LogEntry } from "../../shared/application/use-cases/GetTaskLogsUseCase";
 import { ViewContainer } from "./ViewContainer";
 
 interface ContentAreaProps {
-  activeView: "today" | "logs" | "settings" | TaskCategory;
+  activeView: "today" | "logs" | "settings" | "trash" | TaskCategory;
   loading: boolean;
   
   // Today view props
@@ -37,6 +39,7 @@ interface ContentAreaProps {
   onCreateTaskLog: (taskId: string, content: string) => Promise<void>;
   onDeferTask: (taskId: string, deferredUntil: Date) => Promise<void>;
   onUndeferTask: (taskId: string) => Promise<void>;
+  trashViewModel: TrashViewModel;
 }
 
 export const ContentArea: React.FC<ContentAreaProps> = ({
@@ -58,6 +61,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
   onCreateTaskLog,
   onDeferTask,
   onUndeferTask,
+  trashViewModel,
 }) => {
   if (loading) {
     return (
@@ -99,6 +103,13 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
       return (
         <ViewContainer>
           <Settings />
+        </ViewContainer>
+      );
+
+    case "trash":
+      return (
+        <ViewContainer>
+          <TrashView viewModel={trashViewModel} />
         </ViewContainer>
       );
 

--- a/src/mvp/components/Header.tsx
+++ b/src/mvp/components/Header.tsx
@@ -9,20 +9,25 @@ import {
   Menu,
   Clock,
   Settings,
+  Trash2,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { TaskCategory } from "../../shared/domain/types";
 import { Button } from "../../shared/ui/button";
 
 interface HeaderProps {
-  activeView: "today" | "logs" | "settings" | TaskCategory;
+  activeView: "today" | "logs" | "settings" | "trash" | TaskCategory;
   onMobileMenuToggle: () => void;
 }
 
-const getViewTitle = (view: "today" | "logs" | "settings" | TaskCategory, t: any) => {
+const getViewTitle = (
+  view: "today" | "logs" | "settings" | "trash" | TaskCategory,
+  t: any
+) => {
   if (view === "today") return t("navigation.today");
   if (view === "logs") return t("logs.title", "Activity Logs");
   if (view === "settings") return t("settings.title");
+  if (view === "trash") return t("navigation.trash", "Trash");
 
   switch (view) {
     case TaskCategory.SIMPLE:
@@ -38,11 +43,15 @@ const getViewTitle = (view: "today" | "logs" | "settings" | TaskCategory, t: any
   }
 };
 
-const getViewDescription = (view: "today" | "logs" | "settings" | TaskCategory, t: any) => {
+const getViewDescription = (
+  view: "today" | "logs" | "settings" | "trash" | TaskCategory,
+  t: any
+) => {
   if (view === "today") return t("navigation.descriptions.today");
   if (view === "logs")
     return t("logs.subtitle", "View all system and user activity");
   if (view === "settings") return t("settings.app.description");
+  if (view === "trash") return t("navigation.descriptions.trash", "Deleted tasks");
 
   switch (view) {
     case TaskCategory.SIMPLE:
@@ -58,10 +67,13 @@ const getViewDescription = (view: "today" | "logs" | "settings" | TaskCategory, 
   }
 };
 
-const getViewIcon = (view: "today" | "logs" | "settings" | TaskCategory) => {
+const getViewIcon = (
+  view: "today" | "logs" | "settings" | "trash" | TaskCategory
+) => {
   if (view === "today") return Sun;
   if (view === "logs") return FileText;
   if (view === "settings") return Settings;
+  if (view === "trash") return Trash2;
 
   switch (view) {
     case TaskCategory.SIMPLE:

--- a/src/mvp/components/Sidebar.tsx
+++ b/src/mvp/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Sun, Zap, Target, Inbox, Clock, FileText, Settings } from "lucide-react";
+import { Sun, Zap, Target, Inbox, Clock, FileText, Settings, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { TaskCategory } from "../../shared/domain/types";
 import { Button } from "../../shared/ui/button";
@@ -7,8 +7,10 @@ import { cn } from "../../shared/lib/utils";
 import LiftLogo from "../../../assets/icon.png";
 
 interface SidebarProps {
-  activeView: "today" | "logs" | "settings" | TaskCategory;
-  onViewChange: (view: "today" | "logs" | "settings" | TaskCategory) => void;
+  activeView: "today" | "logs" | "settings" | "trash" | TaskCategory;
+  onViewChange: (
+    view: "today" | "logs" | "settings" | "trash" | TaskCategory
+  ) => void;
   taskCounts: Record<TaskCategory, number>;
   hasOverdueTasks: boolean;
   isMobileMenuOpen: boolean;
@@ -53,6 +55,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
       name: getCategoryInfo(category, t).name,
       count: taskCounts[category] || 0,
     })),
+    {
+      id: "trash" as const,
+      icon: Trash2,
+      name: t("navigation.trash", "Trash"),
+      count: null,
+    },
     {
       id: "logs" as const,
       icon: FileText,

--- a/src/shared/domain/repositories/TaskRepository.ts
+++ b/src/shared/domain/repositories/TaskRepository.ts
@@ -37,6 +37,11 @@ export interface TaskRepository {
   findOverdueTasks(overdueDays: number): Promise<Task[]>;
 
   /**
+   * Find all soft-deleted tasks
+   */
+  findDeleted(): Promise<Task[]>;
+
+  /**
    * Save a task (create or update)
    */
   save(task: Task): Promise<void>;
@@ -50,6 +55,11 @@ export interface TaskRepository {
    * Delete a task permanently (hard delete)
    */
   delete(id: TaskId): Promise<void>;
+
+  /**
+   * Permanently delete all soft-deleted tasks
+   */
+  clearDeleted(): Promise<void>;
 
   /**
    * Count total tasks (active only)

--- a/src/shared/infrastructure/repositories/TaskRepositoryImpl.ts
+++ b/src/shared/infrastructure/repositories/TaskRepositoryImpl.ts
@@ -86,6 +86,14 @@ export class TaskRepositoryImpl implements TaskRepository {
     return records.map((record) => this.mapRecordToEntity(record));
   }
 
+  async findDeleted(): Promise<Task[]> {
+    const records = await this.db.tasks
+      .filter((record) => record.deletedAt != null)
+      .sortBy("updatedAt");
+
+    return records.map((record) => this.mapRecordToEntity(record));
+  }
+
   async save(task: Task): Promise<void> {
     const record = this.mapEntityToRecord(task);
     await this.db.tasks.put(record);
@@ -98,6 +106,10 @@ export class TaskRepositoryImpl implements TaskRepository {
 
   async delete(id: TaskId): Promise<void> {
     await this.db.tasks.delete(id.value);
+  }
+
+  async clearDeleted(): Promise<void> {
+    await this.db.tasks.filter((record) => record.deletedAt != null).delete();
   }
 
   async count(): Promise<number> {

--- a/src/shared/infrastructure/repositories/__tests__/TaskRepositoryImpl.test.ts
+++ b/src/shared/infrastructure/repositories/__tests__/TaskRepositoryImpl.test.ts
@@ -353,7 +353,7 @@ describe('TaskRepositoryImpl', () => {
       const { task } = Task.create(taskId, new NonEmptyTitle('Test Task'), TaskCategory.SIMPLE);
 
       await repository.save(task);
-      
+
       // Verify task exists
       expect(await repository.exists(taskId)).toBe(true);
 
@@ -363,6 +363,29 @@ describe('TaskRepositoryImpl', () => {
       // Verify task is gone
       expect(await repository.exists(taskId)).toBe(false);
       expect(await repository.findById(taskId)).toBeNull();
+    });
+  });
+
+  describe('findDeleted and clearDeleted', () => {
+    it('should return soft-deleted tasks and clear them', async () => {
+      const task1Id = TaskId.generate();
+      const task2Id = TaskId.generate();
+
+      const { task: task1 } = Task.create(task1Id, new NonEmptyTitle('Task 1'), TaskCategory.SIMPLE);
+      const { task: task2 } = Task.create(task2Id, new NonEmptyTitle('Task 2'), TaskCategory.FOCUS);
+
+      task1.softDelete();
+      task2.softDelete();
+
+      await repository.saveMany([task1, task2]);
+
+      const deletedTasks = await repository.findDeleted();
+      expect(deletedTasks).toHaveLength(2);
+
+      await repository.clearDeleted();
+
+      const afterClear = await repository.findDeleted();
+      expect(afterClear).toHaveLength(0);
     });
   });
 

--- a/src/shared/lib/i18n.ts
+++ b/src/shared/lib/i18n.ts
@@ -13,12 +13,14 @@ const resources = {
       navigation: {
         today: "Today",
         settings: "Settings",
+        trash: "Trash",
         descriptions: {
           today: "Focus on what matters most today",
           simple: "Quick tasks that take less than 15 minutes",
           focus: "Important tasks requiring deep concentration",
           inbox: "New tasks waiting to be organized",
           deferred: "Tasks postponed until a specific date",
+          trash: "Deleted tasks",
         },
       },
       common: {
@@ -126,12 +128,14 @@ const resources = {
       navigation: {
         today: "Сегодня",
         settings: "Настройки",
+        trash: "Корзина",
         descriptions: {
           today: "Сосредоточьтесь на важном",
           simple: "Быстрые задачи, которые займут менее 15 минут",
           focus: "Важные задачи, требующие глубокой концентрации",
           inbox: "Новые задачи, ожидающие распределения",
           deferred: "Отложенные задачи до определенной даты",
+          trash: "Удаленные задачи",
         },
         logs: "История",
       },


### PR DESCRIPTION
## Summary
- allow repositories to list and clear soft-deleted tasks
- introduce trash view model and UI to browse and empty trash
- wire up navigation, header, and translations for trash screen

## Testing
- `npm test` *(fails: 26 failed, 14 passed)*
- `npm run lint` *(fails: ESLint: 8.57.1 - configuration file not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f3127f0f88333b01859904fbfb27f