### PR TITLE
fix: inject DebouncedSyncService into CompleteTaskUseCase

### DIFF
--- a/src/shared/application/use-cases/CompleteTaskUseCase.ts
+++ b/src/shared/application/use-cases/CompleteTaskUseCase.ts
@@ -1,10 +1,11 @@
-import { injectable, inject } from 'tsyringe';
-import { Result, ResultUtils } from '../../domain/Result';
-import { BaseTaskUseCase, TaskOperationError } from './BaseTaskUseCase';
-import { TaskRepository } from '../../domain/repositories/TaskRepository';
-import { EventBus } from '../../domain/events/EventBus';
-import { TodoDatabase } from '../../infrastructure/database/TodoDatabase';
-import * as tokens from '../../infrastructure/di/tokens';
+import { injectable, inject } from "tsyringe";
+import { Result, ResultUtils } from "../../domain/Result";
+import { BaseTaskUseCase, TaskOperationError } from "./BaseTaskUseCase";
+import { TaskRepository } from "../../domain/repositories/TaskRepository";
+import { EventBus } from "../../domain/events/EventBus";
+import { TodoDatabase } from "../../infrastructure/database/TodoDatabase";
+import { DebouncedSyncService } from "../services/DebouncedSyncService";
+import * as tokens from "../../infrastructure/di/tokens";
 
 /**
  * Request for completing a task
@@ -19,7 +20,7 @@ export interface CompleteTaskRequest {
 export class TaskCompletionError extends TaskOperationError {
   constructor(message: string, code: string) {
     super(message, code);
-    this.name = 'TaskCompletionError';
+    this.name = "TaskCompletionError";
   }
 }
 
@@ -31,44 +32,54 @@ export class CompleteTaskUseCase extends BaseTaskUseCase {
   constructor(
     @inject(tokens.TASK_REPOSITORY_TOKEN) taskRepository: TaskRepository,
     @inject(tokens.EVENT_BUS_TOKEN) eventBus: EventBus,
-    @inject(tokens.DATABASE_TOKEN) database: TodoDatabase
+    @inject(tokens.DATABASE_TOKEN) database: TodoDatabase,
+    @inject(tokens.DEBOUNCED_SYNC_SERVICE_TOKEN)
+    debouncedSyncService: DebouncedSyncService
   ) {
-    super(taskRepository, eventBus, database);
+    super(taskRepository, eventBus, database, debouncedSyncService);
   }
 
-  async execute(request: CompleteTaskRequest): Promise<Result<void, TaskCompletionError>> {
+  async execute(
+    request: CompleteTaskRequest
+  ): Promise<Result<void, TaskCompletionError>> {
     return this.safeExecute(
       async () => {
         // Find and validate task
         const taskResult = await this.findTaskById(request.taskId);
         if (ResultUtils.isFailure(taskResult)) {
           return ResultUtils.error(
-            new TaskCompletionError(taskResult.error.message, taskResult.error.code)
+            new TaskCompletionError(
+              taskResult.error.message,
+              taskResult.error.code
+            )
           );
         }
 
         const task = taskResult.data;
-        
+
         // Complete the task (domain logic handles validation and events)
         const events = task.complete();
 
         // Execute in transaction
         const transactionResult = await this.executeInTransaction<void>(
           task,
-          'update',
+          "update",
           events
         );
 
         if (ResultUtils.isFailure(transactionResult)) {
           return ResultUtils.error(
-            new TaskCompletionError(transactionResult.error.message, transactionResult.error.code)
+            new TaskCompletionError(
+              transactionResult.error.message,
+              transactionResult.error.code
+            )
           );
         }
 
         return ResultUtils.ok(undefined);
       },
-      'Failed to complete task',
-      'COMPLETION_FAILED'
+      "Failed to complete task",
+      "COMPLETION_FAILED"
     );
   }
 }

--- a/src/shared/application/use-cases/__tests__/RemoveTaskFromTodayUseCase.test.ts
+++ b/src/shared/application/use-cases/__tests__/RemoveTaskFromTodayUseCase.test.ts
@@ -4,9 +4,11 @@ import {
   RemoveTaskFromTodayRequest,
 } from "../RemoveTaskFromTodayUseCase";
 import { DailySelectionRepository } from "../../../domain/repositories/DailySelectionRepository";
+import { EventBus } from "../../../domain/events/EventBus";
 import { TaskId } from "../../../domain/value-objects/TaskId";
 import { DateOnly } from "../../../domain/value-objects/DateOnly";
 import { ResultUtils } from "../../../domain/Result";
+import { DebouncedSyncService } from "../../services/DebouncedSyncService";
 
 // Mock implementations
 const mockDailySelectionRepository: DailySelectionRepository = {
@@ -23,12 +25,29 @@ const mockDailySelectionRepository: DailySelectionRepository = {
   getLastSelectionDateForTask: vi.fn(),
 };
 
+const mockEventBus: EventBus = {
+  publish: vi.fn(),
+  publishAll: vi.fn(),
+  subscribe: vi.fn(),
+  subscribeToAll: vi.fn(),
+  clear: vi.fn(),
+};
+
+const mockDebouncedSyncService: DebouncedSyncService = {
+  triggerSync: vi.fn(),
+  cleanup: vi.fn(),
+} as unknown as DebouncedSyncService;
+
 describe("RemoveTaskFromTodayUseCase", () => {
   let useCase: RemoveTaskFromTodayUseCase;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    useCase = new RemoveTaskFromTodayUseCase(mockDailySelectionRepository);
+    useCase = new RemoveTaskFromTodayUseCase(
+      mockDailySelectionRepository,
+      mockEventBus,
+      mockDebouncedSyncService
+    );
   });
 
   describe("execute", () => {


### PR DESCRIPTION
## Summary
- inject DebouncedSyncService into CompleteTaskUseCase to avoid missing triggerSync
- update use case tests to mock DebouncedSyncService

## Testing
- `npm test` *(fails: Test Files 24 failed | 16 passed | 2 skipped)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688f7b6c087883339838d92dd92a54e0