### PR TITLE
test: fix flaky specs

### DIFF
--- a/src/features/onboarding/application/services/__tests__/OnboardingService.test.ts
+++ b/src/features/onboarding/application/services/__tests__/OnboardingService.test.ts
@@ -359,7 +359,6 @@ describe("OnboardingService", () => {
         overdueDate
       );
 
-      const fixedDate = new Date("2023-12-01T12:00:00Z");
       const regularInboxTask = new Task(
         TaskId.generate(),
         new NonEmptyTitle("Regular Inbox Task"),

--- a/src/features/onboarding/presentation/view-models/__tests__/OnboardingViewModel.test.ts
+++ b/src/features/onboarding/presentation/view-models/__tests__/OnboardingViewModel.test.ts
@@ -67,6 +67,7 @@ vi.mock("../../../../../shared/infrastructure/database/TodoDatabase", () => ({
   todoDatabase: {
     userSettings: {
       toArray: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue(null),
     },
   },
 }));

--- a/src/features/today/presentation/view-models/__tests__/TodayViewModel.test.ts
+++ b/src/features/today/presentation/view-models/__tests__/TodayViewModel.test.ts
@@ -22,10 +22,6 @@ import {
   createTodayViewModel,
   TodayViewModelDependencies,
 } from "../TodayViewModel";
-import { DateOnly } from "../../../../../shared/domain/value-objects/DateOnly";
-
-// Mock DateOnly.today() to return consistent date
-vi.spyOn(DateOnly, "today").mockReturnValue(new DateOnly("2023-12-01"));
 
 // Mock dependencies
 const mockGetTodayTasksUseCase: GetTodayTasksUseCase = {

--- a/src/shared/application/use-cases/GetTaskLogsUseCase.ts
+++ b/src/shared/application/use-cases/GetTaskLogsUseCase.ts
@@ -89,7 +89,7 @@ export class GetTaskLogsUseCase {
       // Validate and set pagination parameters
       const page = Math.max(1, request.page || 1);
       let requestedPageSize =
-        request.pageSize || GetTaskLogsUseCase.DEFAULT_PAGE_SIZE;
+        request.pageSize ?? GetTaskLogsUseCase.DEFAULT_PAGE_SIZE;
       // Handle edge case where pageSize is 0 or negative
       if (requestedPageSize <= 0) {
         requestedPageSize = 1;

--- a/src/shared/application/use-cases/__tests__/GetTodayTasksUseCase.test.ts
+++ b/src/shared/application/use-cases/__tests__/GetTodayTasksUseCase.test.ts
@@ -118,8 +118,9 @@ describe("GetTodayTasksUseCase", () => {
         expect(response.tasks[1].completedInSelection).toBe(false);
       }
 
+      const today = DateOnly.today().value;
       expect(mockDailySelectionRepository.getTasksForDay).toHaveBeenCalledWith(
-        DateOnly.today()
+        expect.objectContaining({ value: today })
       );
       expect(mockTaskRepository.findById).toHaveBeenCalledTimes(2);
     });
@@ -164,7 +165,7 @@ describe("GetTodayTasksUseCase", () => {
       }
 
       expect(mockDailySelectionRepository.getTasksForDay).toHaveBeenCalledWith(
-        DateOnly.fromString(specificDate)
+        expect.objectContaining({ value: specificDate })
       );
     });
 

--- a/src/shared/domain/__tests__/Task.test.ts
+++ b/src/shared/domain/__tests__/Task.test.ts
@@ -31,6 +31,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.SIMPLE,
         TaskStatus.ACTIVE,
+        now.getTime(),
         now,
         now
       );
@@ -53,6 +54,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.INBOX,
         TaskStatus.ACTIVE,
+        now.getTime(),
         now,
         now
       );
@@ -67,6 +69,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.SIMPLE,
         TaskStatus.ACTIVE,
+        now.getTime(),
         now,
         now
       );
@@ -81,6 +84,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.SIMPLE,
         TaskStatus.ACTIVE,
+        now.getTime(),
         now,
         now
       );
@@ -95,6 +99,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.INBOX,
         TaskStatus.ACTIVE,
+        now.getTime(),
         now,
         now
       );
@@ -316,7 +321,8 @@ describe("Task Entity", () => {
 
   describe("isOverdue", () => {
     it("should return true for overdue INBOX tasks", () => {
-      const pastDate = new Date();
+      const baseDate = new Date("2023-12-01T12:00:00Z");
+      const pastDate = new Date(baseDate);
       pastDate.setDate(pastDate.getDate() - 5); // 5 days ago
 
       task = new Task(
@@ -324,6 +330,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.INBOX,
         TaskStatus.ACTIVE,
+        pastDate.getTime(),
         pastDate,
         pastDate,
         undefined,
@@ -334,7 +341,8 @@ describe("Task Entity", () => {
     });
 
     it("should return false for non-overdue INBOX tasks", () => {
-      const recentDate = new Date();
+      const baseDate = new Date("2023-12-01T12:00:00Z");
+      const recentDate = new Date(baseDate);
       recentDate.setDate(recentDate.getDate() - 1); // 1 day ago
 
       task = new Task(
@@ -342,6 +350,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.INBOX,
         TaskStatus.ACTIVE,
+        recentDate.getTime(),
         recentDate,
         recentDate,
         undefined,
@@ -352,7 +361,7 @@ describe("Task Entity", () => {
     });
 
     it("should return false for non-INBOX tasks", () => {
-      const pastDate = new Date();
+      const pastDate = new Date("2023-12-01T12:00:00Z");
       pastDate.setDate(pastDate.getDate() - 10);
 
       task = new Task(
@@ -360,6 +369,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.SIMPLE,
         TaskStatus.ACTIVE,
+        pastDate.getTime(),
         pastDate,
         pastDate
       );
@@ -368,7 +378,7 @@ describe("Task Entity", () => {
     });
 
     it("should return false for completed INBOX tasks", () => {
-      const pastDate = new Date();
+      const pastDate = new Date("2023-12-01T12:00:00Z");
       pastDate.setDate(pastDate.getDate() - 5);
 
       task = new Task(
@@ -376,6 +386,7 @@ describe("Task Entity", () => {
         title,
         TaskCategory.INBOX,
         TaskStatus.COMPLETED,
+        pastDate.getTime(),
         pastDate,
         pastDate,
         undefined,
@@ -386,13 +397,15 @@ describe("Task Entity", () => {
     });
 
     it("should return false when inboxEnteredAt is not set", () => {
+      const baseDate = new Date("2023-12-01T12:00:00Z");
       task = new Task(
         taskId,
         title,
         TaskCategory.INBOX,
         TaskStatus.ACTIVE,
-        new Date(),
-        new Date()
+        baseDate.getTime(),
+        baseDate,
+        baseDate
       );
 
       expect(task.isOverdue(3)).toBe(false);

--- a/src/shared/infrastructure/database/__tests__/TodoDatabase.test.ts
+++ b/src/shared/infrastructure/database/__tests__/TodoDatabase.test.ts
@@ -170,6 +170,7 @@ describe("TodoDatabase", () => {
   describe("Daily Selection Entries Table", () => {
     it("should create daily selection entry with automatic timestamp", async () => {
       const entryData: DailySelectionEntryRecord = {
+        id: "entry_1",
         date: "2024-01-15",
         taskId: "task_123",
         completedFlag: false,
@@ -188,6 +189,7 @@ describe("TodoDatabase", () => {
 
     it("should enforce unique constraint on date+taskId combination", async () => {
       const entryData: DailySelectionEntryRecord = {
+        id: "entry_1",
         date: "2024-01-15",
         taskId: "task_123",
         completedFlag: false,
@@ -209,18 +211,21 @@ describe("TodoDatabase", () => {
     it("should filter by date", async () => {
       await db.dailySelectionEntries.bulkAdd([
         {
+          id: "entry_1",
           date: "2024-01-15",
           taskId: "task_1",
           completedFlag: false,
           createdAt: new Date(),
         },
         {
+          id: "entry_2",
           date: "2024-01-15",
           taskId: "task_2",
           completedFlag: true,
           createdAt: new Date(),
         },
         {
+          id: "entry_3",
           date: "2024-01-16",
           taskId: "task_3",
           completedFlag: false,
@@ -245,6 +250,7 @@ describe("TodoDatabase", () => {
   describe("Task Logs Table", () => {
     it("should create task log with automatic timestamp", async () => {
       const logData: TaskLogRecord = {
+        id: "log_1",
         taskId: "task_123",
         type: "SYSTEM",
         message: "Task created",
@@ -263,6 +269,7 @@ describe("TodoDatabase", () => {
 
     it("should create custom log without taskId", async () => {
       const logData: TaskLogRecord = {
+        id: "log_2",
         type: "USER",
         message: "Custom user log",
         createdAt: new Date(),
@@ -280,18 +287,21 @@ describe("TodoDatabase", () => {
     it("should filter logs by taskId", async () => {
       await db.taskLogs.bulkAdd([
         {
+          id: "log_3",
           taskId: "task_1",
           type: "SYSTEM",
           message: "Task 1 created",
           createdAt: new Date(),
         },
         {
+          id: "log_4",
           taskId: "task_1",
           type: "USER",
           message: "Working on task 1",
           createdAt: new Date(),
         },
         {
+          id: "log_5",
           taskId: "task_2",
           type: "SYSTEM",
           message: "Task 2 created",
@@ -315,18 +325,21 @@ describe("TodoDatabase", () => {
     it("should filter logs by type", async () => {
       await db.taskLogs.bulkAdd([
         {
+          id: "log_6",
           taskId: "task_1",
           type: "SYSTEM",
           message: "System log 1",
           createdAt: new Date(),
         },
         {
+          id: "log_7",
           taskId: "task_2",
           type: "USER",
           message: "User log 1",
           createdAt: new Date(),
         },
         {
+          id: "log_8",
           taskId: "task_3",
           type: "CONFLICT",
           message: "Conflict log 1",

--- a/src/shared/presentation/hooks/__tests__/useSync.test.tsx
+++ b/src/shared/presentation/hooks/__tests__/useSync.test.tsx
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  vi,
+} from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useSync } from "../useSync";
 import { syncInitializer } from "../../../infrastructure/sync/SyncInitializer";
@@ -53,9 +61,14 @@ Object.defineProperty(window, "removeEventListener", {
 });
 
 describe("useSync", () => {
-  const { mockSyncService, mockRealtimeService } = vi.mocked(
-    await import("../../../infrastructure/sync/SyncInitializer")
-  );
+  let mockSyncService: any;
+  let mockRealtimeService: any;
+
+  beforeAll(async () => {
+    const module = await import("../../../infrastructure/sync/SyncInitializer");
+    mockSyncService = module.mockSyncService;
+    mockRealtimeService = module.mockRealtimeService;
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
+    exclude: ["tests/**"],
     typecheck: {
       include: ["**/*.{test,spec}.{ts,tsx}"],
     },


### PR DESCRIPTION
## Summary
- ensure DailySelectionEntry and TaskLog tests supply explicit IDs
- avoid duplicate test data setup and adjust mocks in various tests
- handle zero pageSize correctly in GetTaskLogsUseCase
- exclude Playwright specs from vitest run

## Testing
- `npm test` *(fails: DatabaseClosedError, unresolved DI tokens, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68950b0a5c2c8333bc1f52904e63ca9e