### PR TITLE
feat: add image upload with local storage and p2p sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,10 @@
         "react-dom": "^18.2.0",
         "react-i18next": "^15.6.0",
         "reflect-metadata": "^0.2.2",
+        "simple-peer": "^9.11.1",
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
+        "thumbhash": "^0.1.1",
         "tsyringe": "^4.10.0",
         "ulid": "^2.4.0",
         "zustand": "^4.4.1"
@@ -4617,6 +4619,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4684,6 +4706,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5258,7 +5304,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5527,6 +5572,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -6314,6 +6365,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
+      "license": "MIT"
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
@@ -6761,6 +6818,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6824,7 +6901,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -8204,7 +8280,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -8948,7 +9023,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8969,7 +9043,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -9171,6 +9244,20 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -9486,7 +9573,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9758,6 +9844,35 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-peer": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
+      "integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "debug": "^4.3.2",
+        "err-code": "^3.0.1",
+        "get-browser-rtc": "^1.1.0",
+        "queue-microtask": "^1.2.3",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9935,6 +10050,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -10440,6 +10564,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thumbhash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/thumbhash/-/thumbhash-0.1.1.tgz",
+      "integrity": "sha512-kH5pKeIIBPQXAOni2AiY/Cu/NKdkFREdpH+TLdM0g6WA7RriCv0kPLgP731ady67MhTAqrVG/4mnEeibVuCJcg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -10907,7 +11037,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.6.0",
     "reflect-metadata": "^0.2.2",
+    "simple-peer": "^9.11.1",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
+    "thumbhash": "^0.1.1",
     "tsyringe": "^4.10.0",
     "ulid": "^2.4.0",
     "zustand": "^4.4.1"

--- a/src/features/tasks/presentation/components/CreateTaskModal.tsx
+++ b/src/features/tasks/presentation/components/CreateTaskModal.tsx
@@ -6,7 +6,11 @@ import { TaskCategory } from "../../../../shared/domain/types";
 interface CreateTaskModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (title: string, category: TaskCategory) => Promise<boolean>;
+  onSubmit: (
+    title: string,
+    category: TaskCategory,
+    image?: File
+  ) => Promise<boolean>;
   initialTitle?: string;
   initialCategory?: TaskCategory;
   hideCategorySelection?: boolean;

--- a/src/shared/application/use-cases/CreateTaskUseCase.ts
+++ b/src/shared/application/use-cases/CreateTaskUseCase.ts
@@ -17,6 +17,7 @@ import * as tokens from "../../infrastructure/di/tokens";
 export interface CreateTaskRequest {
   title: string;
   category: TaskCategory;
+  image?: File;
 }
 
 /**
@@ -73,7 +74,20 @@ export class CreateTaskUseCase extends BaseTaskUseCase {
         }
 
         // Create task entity
-        const { task, events } = Task.create(taskId, title, request.category);
+        let thumbhash: string | undefined;
+        if (request.image) {
+          const { generateThumbhash } = await import(
+            "../../infrastructure/utils/thumbhash"
+          );
+          thumbhash = await generateThumbhash(request.image);
+        }
+        const { task, events } = Task.create(
+          taskId,
+          title,
+          request.category,
+          thumbhash,
+          request.image
+        );
 
         // Execute in transaction (this will trigger sync)
         const transactionResult = await this.executeInTransaction<void>(

--- a/src/shared/application/use-cases/UpdateTaskUseCase.ts
+++ b/src/shared/application/use-cases/UpdateTaskUseCase.ts
@@ -17,6 +17,7 @@ export interface UpdateTaskRequest {
   title?: string;
   category?: TaskCategory;
   order?: number;
+  image?: File;
 }
 
 /**
@@ -56,7 +57,7 @@ export class UpdateTaskUseCase extends BaseTaskUseCase {
           );
         }
 
-        const task = taskResult.data;
+        let task = taskResult.data;
         const allEvents: any[] = [];
 
         // Update title if provided
@@ -87,6 +88,18 @@ export class UpdateTaskUseCase extends BaseTaskUseCase {
         if (request.order !== undefined) {
           const orderEvents = task.changeOrder(request.order);
           allEvents.push(...orderEvents);
+        }
+
+        if (request.image) {
+          const { generateThumbhash } = await import(
+            "../../infrastructure/utils/thumbhash"
+          );
+          const thumbhash = await generateThumbhash(request.image);
+          task = task.copyWith({
+            thumbhash,
+            image: request.image,
+            updatedAt: new Date(),
+          });
         }
 
         // Execute in transaction

--- a/src/shared/domain/entities/Task.ts
+++ b/src/shared/domain/entities/Task.ts
@@ -38,6 +38,8 @@ export class Task {
   private _wasEverReviewed: boolean = false;
   private _deferredUntil?: Date;
   private _originalCategory?: TaskCategory;
+  private _thumbhash?: string;
+  private _image?: Blob;
   public readonly inboxEnteredAt?: Date;
 
   constructor(
@@ -51,7 +53,9 @@ export class Task {
     deletedAt?: Date,
     inboxEnteredAt?: Date,
     deferredUntil?: Date,
-    originalCategory?: TaskCategory
+    originalCategory?: TaskCategory,
+    thumbhash?: string,
+    image?: Blob
   ) {
     this._title = title;
     this._category = category;
@@ -61,6 +65,8 @@ export class Task {
     this._deletedAt = deletedAt;
     this._deferredUntil = deferredUntil;
     this._originalCategory = originalCategory;
+    this._thumbhash = thumbhash;
+    this._image = image;
 
     // Set inboxEnteredAt if not provided and category is INBOX
     this.inboxEnteredAt =
@@ -120,6 +126,14 @@ export class Task {
     return this._originalCategory;
   }
 
+  get thumbhash(): string | undefined {
+    return this._thumbhash;
+  }
+
+  get image(): Blob | undefined {
+    return this._image;
+  }
+
   get isDeferred(): boolean {
     return (
       this._category === TaskCategory.DEFERRED &&
@@ -144,7 +158,9 @@ export class Task {
   static create(
     id: TaskId,
     title: NonEmptyTitle,
-    category: TaskCategory
+    category: TaskCategory,
+    thumbhash?: string,
+    image?: Blob
   ): { task: Task; events: DomainEvent[] } {
     const now = new Date();
     const task = new Task(
@@ -156,7 +172,11 @@ export class Task {
       now,
       now,
       undefined,
-      category === TaskCategory.INBOX ? now : undefined
+      category === TaskCategory.INBOX ? now : undefined,
+      undefined,
+      undefined,
+      thumbhash,
+      image
     );
 
     const events = [new TaskCreatedEvent(id, title, category)];
@@ -382,6 +402,8 @@ export class Task {
     deletedAt?: Date;
     deferredUntil?: Date;
     originalCategory?: TaskCategory;
+    thumbhash?: string;
+    image?: Blob;
   }): Task {
     return new Task(
       this.id,
@@ -394,7 +416,9 @@ export class Task {
       updates.deletedAt ?? this._deletedAt,
       this.inboxEnteredAt,
       updates.deferredUntil ?? this._deferredUntil,
-      updates.originalCategory ?? this._originalCategory
+      updates.originalCategory ?? this._originalCategory,
+      updates.thumbhash ?? this._thumbhash,
+      updates.image ?? this._image
     );
   }
 }

--- a/src/shared/infrastructure/database/TodoDatabase.ts
+++ b/src/shared/infrastructure/database/TodoDatabase.ts
@@ -15,6 +15,8 @@ export interface TaskRecord {
   inboxEnteredAt?: Date;
   deferredUntil?: Date;
   originalCategory?: TaskCategory;
+  thumbhash?: string;
+  image?: Blob;
 }
 
 export interface DailySelectionEntryRecord {
@@ -304,6 +306,31 @@ export class TodoDatabase extends Dexie {
             });
           }
         }
+      });
+
+    // Version 8 - Add thumbhash and image support for tasks
+    this.version(8)
+      .stores({
+        tasks:
+          "id, category, status, order, createdAt, updatedAt, deletedAt, inboxEnteredAt, deferredUntil, originalCategory, thumbhash",
+        dailySelectionEntries:
+          "id, [date+taskId], date, taskId, completedFlag, createdAt, updatedAt, deletedAt",
+        taskLogs: "id, taskId, type, createdAt",
+        userSettings: "key, updatedAt",
+        syncQueue:
+          "++id, entityType, entityId, operation, attemptCount, createdAt, lastAttemptAt, nextAttemptAt",
+        statsDaily:
+          "date, simpleCompleted, focusCompleted, inboxReviewed, createdAt",
+        eventStore:
+          "id, status, aggregateId, [aggregateId+createdAt], nextAttemptAt, attemptCount, createdAt",
+        handledEvents: "[eventId+handlerId], eventId, handlerId",
+        locks: "id, expiresAt",
+      })
+      .upgrade(async (_trans) => {
+        console.log(
+          "Upgrading database to version 8 - adding thumbhash and image support for tasks"
+        );
+        // No migration needed for optional fields
       });
 
     // Add hooks for automatic timestamp updates

--- a/src/shared/infrastructure/database/supabase-types.ts
+++ b/src/shared/infrastructure/database/supabase-types.ts
@@ -173,6 +173,7 @@ export type Database = {
           original_category:
             | Database["public"]["Enums"]["task_category"]
             | null;
+          thumbhash: string | null;
           status: Database["public"]["Enums"]["task_status"];
           sync_version: number;
           title: string;
@@ -191,6 +192,7 @@ export type Database = {
           original_category?:
             | Database["public"]["Enums"]["task_category"]
             | null;
+          thumbhash?: string | null;
           status?: Database["public"]["Enums"]["task_status"];
           sync_version?: number;
           title: string;
@@ -209,6 +211,7 @@ export type Database = {
           original_category?:
             | Database["public"]["Enums"]["task_category"]
             | null;
+          thumbhash?: string | null;
           status?: Database["public"]["Enums"]["task_status"];
           sync_version?: number;
           title?: string;

--- a/src/shared/infrastructure/repositories/SupabaseSyncRepository.ts
+++ b/src/shared/infrastructure/repositories/SupabaseSyncRepository.ts
@@ -347,6 +347,7 @@ export class SupabaseSyncRepository implements SyncRepository {
         ? SupabaseUtils.toISOString(task.deferredUntil)
         : null,
       original_category: task.originalCategory || null,
+      thumbhash: task.thumbhash || null,
       user_id: this.userId, // Всегда используем текущий user_id
     };
   }
@@ -372,7 +373,8 @@ export class SupabaseSyncRepository implements SyncRepository {
       row.deferred_until
         ? SupabaseUtils.fromISOString(row.deferred_until)
         : undefined,
-      row.original_category as TaskCategory | undefined
+      row.original_category as TaskCategory | undefined,
+      row.thumbhash || undefined
     );
   }
 

--- a/src/shared/infrastructure/repositories/TaskRepositoryImpl.ts
+++ b/src/shared/infrastructure/repositories/TaskRepositoryImpl.ts
@@ -156,7 +156,9 @@ export class TaskRepositoryImpl implements TaskRepository {
       record.deletedAt,
       record.inboxEnteredAt,
       record.deferredUntil,
-      record.originalCategory
+      record.originalCategory,
+      record.thumbhash,
+      record.image
     );
   }
 
@@ -176,6 +178,8 @@ export class TaskRepositoryImpl implements TaskRepository {
       inboxEnteredAt: task.inboxEnteredAt,
       deferredUntil: task.deferredUntil,
       originalCategory: task.originalCategory,
+      thumbhash: task.thumbhash,
+      image: task.image,
     };
   }
 }

--- a/src/shared/infrastructure/sync/P2PImageSyncService.ts
+++ b/src/shared/infrastructure/sync/P2PImageSyncService.ts
@@ -1,0 +1,52 @@
+import Peer from "simple-peer";
+
+/**
+ * Simple peer-to-peer image synchronization service using WebRTC (simple-peer).
+ * This service broadcasts image updates between connected peers. It is a
+ * lightweight approximation of syncthing-style direct synchronization.
+ */
+export class P2PImageSyncService {
+  private peers: Peer.Instance[] = [];
+
+  /** Callback invoked when an image is received from a peer */
+  public onImage?: (taskId: string, imageBase64: string) => void;
+
+  /**
+   * Create a new peer connection. The returned peer should have its signalling
+   * data exchanged with a remote peer through any signalling server.
+   */
+  connect(initiator: boolean): Peer.Instance {
+    const peer = new Peer({ initiator, trickle: false });
+    peer.on("data", (data) => {
+      try {
+        const msg = JSON.parse(data.toString()) as {
+          taskId: string;
+          image: string;
+        };
+        this.onImage?.(msg.taskId, msg.image);
+      } catch {
+        // Ignore malformed messages
+      }
+    });
+    this.peers.push(peer);
+    return peer;
+  }
+
+  /**
+   * Broadcast an image associated with a task to all connected peers.
+   */
+  broadcastImage(taskId: string, image: Blob): void {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const message = JSON.stringify({ taskId, image: reader.result });
+      for (const peer of this.peers) {
+        try {
+          peer.send(message);
+        } catch {
+          // Ignore send errors
+        }
+      }
+    };
+    reader.readAsDataURL(image);
+  }
+}

--- a/src/shared/infrastructure/sync/index.ts
+++ b/src/shared/infrastructure/sync/index.ts
@@ -57,6 +57,9 @@ export {
   default as SyncStatusIndicatorDefault,
 } from "../../presentation/components/SyncStatusIndicator";
 
+// P2P image synchronization service
+export { P2PImageSyncService } from "./P2PImageSyncService";
+
 // Типы
 export type {
   SyncResult,

--- a/src/shared/infrastructure/utils/thumbhash.ts
+++ b/src/shared/infrastructure/utils/thumbhash.ts
@@ -1,0 +1,20 @@
+import { rgbaToThumbHash } from "thumbhash";
+
+/**
+ * Generate a thumbhash (base64 encoded) from an image File.
+ * Uses canvas to extract pixel data in the browser environment.
+ */
+export async function generateThumbhash(file: File): Promise<string> {
+  const bitmap = await createImageBitmap(file);
+  const canvas = document.createElement("canvas");
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context not available");
+  ctx.drawImage(bitmap, 0, 0);
+  const imageData = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+  const hash = rgbaToThumbHash(bitmap.width, bitmap.height, imageData.data);
+  let binary = "";
+  hash.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary);
+}

--- a/src/shared/presentation/components/CreateTaskModal.tsx
+++ b/src/shared/presentation/components/CreateTaskModal.tsx
@@ -5,7 +5,11 @@ import { TaskCategory } from "../../domain/types";
 interface CreateTaskModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (title: string, category: TaskCategory) => Promise<boolean>;
+  onSubmit: (
+    title: string,
+    category: TaskCategory,
+    image?: File
+  ) => Promise<boolean>;
   initialTitle?: string;
   initialCategory?: TaskCategory;
   hideCategorySelection?: boolean;
@@ -75,6 +79,7 @@ export const CreateTaskModal: React.FC<CreateTaskModalProps> = ({
 }) => {
   const [title, setTitle] = useState(initialTitle);
   const [category, setCategory] = useState(initialCategory);
+  const [image, setImage] = useState<File | undefined>(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -83,6 +88,7 @@ export const CreateTaskModal: React.FC<CreateTaskModalProps> = ({
     if (isOpen) {
       setTitle(initialTitle);
       setCategory(initialCategory);
+      setImage(undefined);
       setError(null);
     }
   }, [isOpen, initialTitle, initialCategory]);
@@ -113,11 +119,12 @@ export const CreateTaskModal: React.FC<CreateTaskModalProps> = ({
     setError(null);
 
     try {
-      const success = await onSubmit(title.trim(), category);
+      const success = await onSubmit(title.trim(), category, image);
       if (success) {
         onClose();
         setTitle("");
         setCategory(TaskCategory.INBOX);
+        setImage(undefined);
       } else {
         setError(t("createTaskModal.failedToCreate"));
       }
@@ -198,6 +205,20 @@ export const CreateTaskModal: React.FC<CreateTaskModalProps> = ({
                 autoFocus
                 disabled={isSubmitting}
                 data-testid="task-title-input"
+              />
+            </div>
+
+            {/* Image Upload */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Image
+              </label>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={(e) => setImage(e.target.files?.[0])}
+                disabled={isSubmitting}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none"
               />
             </div>
 

--- a/supabase/migrations/20250802183000_add_thumbhash_to_tasks.sql
+++ b/supabase/migrations/20250802183000_add_thumbhash_to_tasks.sql
@@ -1,0 +1,2 @@
+-- Add thumbhash column to tasks table
+ALTER TABLE tasks ADD COLUMN thumbhash TEXT;


### PR DESCRIPTION
## Summary
- allow tasks to hold image blobs and thumbhash metadata
- compute thumbhashes when creating or updating tasks
- introduce WebRTC-based P2PImageSyncService for direct image sync

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND, DI container not configured, 17 failed | 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68951e9ea804833383e63990972f6c3a