### PR TITLE
feat: add task image upload support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,11 @@
         "react-day-picker": "^9.8.1",
         "react-dom": "^18.2.0",
         "react-i18next": "^15.6.0",
+        "react-photo-view": "^1.2.4",
         "reflect-metadata": "^0.2.2",
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
+        "thumbhash": "^0.1.1",
         "tsyringe": "^4.10.0",
         "ulid": "^2.4.0",
         "zustand": "^4.4.1"
@@ -9084,6 +9086,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-photo-view": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/react-photo-view/-/react-photo-view-1.2.7.tgz",
+      "integrity": "sha512-MfOWVPxuibncRLaycZUNxqYU8D9IA+rbGDDaq6GM8RIoGJal592hEJoRAyRSI7ZxyyJNJTLMUWWL3UIXHJJOpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -10439,6 +10451,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/thumbhash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/thumbhash/-/thumbhash-0.1.1.tgz",
+      "integrity": "sha512-kH5pKeIIBPQXAOni2AiY/Cu/NKdkFREdpH+TLdM0g6WA7RriCv0kPLgP731ady67MhTAqrVG/4mnEeibVuCJcg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.6.0",
     "reflect-metadata": "^0.2.2",
+    "thumbhash": "^0.1.1",
+    "react-photo-view": "^1.2.4",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tsyringe": "^4.10.0",

--- a/src/features/tasks/presentation/components/TaskCard.tsx
+++ b/src/features/tasks/presentation/components/TaskCard.tsx
@@ -19,6 +19,7 @@ import { TaskActions } from "./task-card/TaskActions";
 import { TaskLogsDisplay } from "./task-card/TaskLogsDisplay";
 import { TaskLogsModal } from "./task-card/TaskLogsModal";
 import { TaskDeferModal } from "./task-card/TaskDeferModal";
+import { TaskImages } from "./task-card/TaskImages";
 
 // Хуки
 import { useTaskEditing } from "./task-card/hooks/useTaskEditing";
@@ -254,6 +255,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
           onToggleLogHistory={handleToggleLogHistory}
           onCreateLog={onCreateLog}
         />
+        <TaskImages taskId={task.id.value} />
       </motion.article>
 
       {/* Modals */}

--- a/src/features/tasks/presentation/components/task-card/TaskImages.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskImages.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState, useCallback } from "react";
+import {
+  TaskImageService,
+  thumbhashToDataUrl,
+} from "../../../../shared/infrastructure/services/TaskImageService";
+import {
+  TodoDatabase,
+  TaskImageRecord,
+} from "../../../../shared/infrastructure/database/TodoDatabase";
+import { PhotoProvider, PhotoView } from "react-photo-view";
+import "react-photo-view/dist/react-photo-view.css";
+
+interface Props {
+  taskId: string;
+}
+
+export const TaskImages: React.FC<Props> = ({ taskId }) => {
+  const [images, setImages] = useState<TaskImageRecord[]>([]);
+  const service = new TaskImageService(new TodoDatabase());
+
+  const load = useCallback(async () => {
+    const imgs = await service.getImages(taskId);
+    setImages(imgs);
+  }, [service, taskId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files) return;
+    await service.addImages(taskId, Array.from(files));
+    await load();
+  };
+
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    await handleFiles(e.dataTransfer.files);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  return (
+    <div onDragOver={handleDragOver} onDrop={handleDrop} className="mt-2">
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={(e) => handleFiles(e.target.files)}
+        className="hidden"
+        id={`task-image-input-${taskId}`}
+      />
+      <label
+        htmlFor={`task-image-input-${taskId}`}
+        className="cursor-pointer text-sm text-blue-600 hover:underline"
+      >
+        Add images
+      </label>
+      {images.length > 0 && (
+        <PhotoProvider>
+          <div className="flex gap-2 flex-wrap mt-2">
+            {images.map((img) => {
+              const src = thumbhashToDataUrl(img.thumbhash);
+              return (
+                <PhotoView key={img.id} src={URL.createObjectURL(img.data)}>
+                  <img
+                    src={src}
+                    alt=""
+                    className="w-20 h-20 object-cover rounded border"
+                  />
+                </PhotoView>
+              );
+            })}
+          </div>
+        </PhotoProvider>
+      )}
+    </div>
+  );
+};

--- a/src/shared/infrastructure/services/TaskImageService.ts
+++ b/src/shared/infrastructure/services/TaskImageService.ts
@@ -1,0 +1,68 @@
+import { ulid } from "ulid";
+import { rgbaToThumbHash, thumbHashToDataURL } from "thumbhash";
+import { TodoDatabase, TaskImageRecord } from "../database/TodoDatabase";
+
+export class TaskImageService {
+  constructor(private db: TodoDatabase) {}
+
+  private async fileToThumbhash(file: File): Promise<string> {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    try {
+      await new Promise((resolve, reject) => {
+        img.onload = () => resolve(null);
+        img.onerror = (e) => reject(e);
+        img.src = url;
+      });
+      const canvas = document.createElement("canvas");
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Canvas context not available");
+      ctx.drawImage(img, 0, 0);
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const hash = rgbaToThumbHash(
+        imageData.width,
+        imageData.height,
+        imageData.data
+      );
+      let binary = "";
+      hash.forEach((b) => (binary += String.fromCharCode(b)));
+      return btoa(binary);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  async addImages(taskId: string, files: File[]): Promise<TaskImageRecord[]> {
+    await this.db.initialize();
+    const records: TaskImageRecord[] = [];
+    for (const file of files) {
+      const thumbhash = await this.fileToThumbhash(file);
+      const record: TaskImageRecord = {
+        id: ulid(),
+        taskId,
+        data: file,
+        thumbhash,
+        createdAt: new Date(),
+      };
+      await this.db.taskImages.put(record);
+      records.push(record);
+    }
+    return records;
+  }
+
+  async getImages(taskId: string): Promise<TaskImageRecord[]> {
+    await this.db.initialize();
+    return await this.db.taskImages.where("taskId").equals(taskId).toArray();
+  }
+}
+
+export function thumbhashToDataUrl(hash: string): string {
+  const binary = atob(hash);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return thumbHashToDataURL(bytes);
+}


### PR DESCRIPTION
## Summary
- add task image table to Dexie database schema
- implement TaskImageService and TaskImages component with drag-and-drop and viewer
- integrate image listing into TaskCard

## Testing
- `npm test` *(fails: realtimeService.on is not a function, missing environment variables, Dexie errors)*

------
https://chatgpt.com/codex/tasks/task_e_68957302955083338ae8cde2477e7b64