### PR TITLE
feat: add task image attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,11 @@
         "react-day-picker": "^9.8.1",
         "react-dom": "^18.2.0",
         "react-i18next": "^15.6.0",
+        "react-photo-view": "^1.2.7",
         "reflect-metadata": "^0.2.2",
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
+        "thumbhash": "^0.1.1",
         "tsyringe": "^4.10.0",
         "ulid": "^2.4.0",
         "zustand": "^4.4.1"
@@ -9084,6 +9086,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-photo-view": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/react-photo-view/-/react-photo-view-1.2.7.tgz",
+      "integrity": "sha512-MfOWVPxuibncRLaycZUNxqYU8D9IA+rbGDDaq6GM8RIoGJal592hEJoRAyRSI7ZxyyJNJTLMUWWL3UIXHJJOpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -10439,6 +10451,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/thumbhash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/thumbhash/-/thumbhash-0.1.1.tgz",
+      "integrity": "sha512-kH5pKeIIBPQXAOni2AiY/Cu/NKdkFREdpH+TLdM0g6WA7RriCv0kPLgP731ady67MhTAqrVG/4mnEeibVuCJcg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,11 @@
     "react-day-picker": "^9.8.1",
     "react-dom": "^18.2.0",
     "react-i18next": "^15.6.0",
+    "react-photo-view": "^1.2.7",
     "reflect-metadata": "^0.2.2",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
+    "thumbhash": "^0.1.1",
     "tsyringe": "^4.10.0",
     "ulid": "^2.4.0",
     "zustand": "^4.4.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import "./App.css";
+import "react-photo-view/dist/react-photo-view.css";
 import { MVPApp } from "./mvp/MVPApp";
 
 function App() {

--- a/src/features/tasks/presentation/components/TaskList.tsx
+++ b/src/features/tasks/presentation/components/TaskList.tsx
@@ -46,7 +46,11 @@ interface TaskListProps {
   onCreateLog?: (taskId: string, message: string) => Promise<boolean>;
   lastLogs?: Record<string, LogEntry>;
   emptyMessage?: string;
-  onCreateTask?: (title: string, category: TaskCategory) => Promise<boolean>;
+  onCreateTask?: (
+    title: string,
+    category: TaskCategory,
+    images?: File[]
+  ) => Promise<boolean>;
   currentCategory?: TaskCategory;
 }
 

--- a/src/features/tasks/presentation/components/task-card/TaskActions.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskActions.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { TaskStatus } from "../../../../../shared/domain/types";
 import { useTranslation } from "react-i18next";
-import { Check, Undo2, MoreHorizontal, Clock, Trash2 } from "lucide-react";
+import {
+  Check,
+  Undo2,
+  MoreHorizontal,
+  Clock,
+  Trash2,
+  ImagePlus,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +25,7 @@ interface TaskActionsProps {
   onRevertCompletion?: (taskId: string) => void;
   onDelete: (taskId: string) => void;
   onDefer?: () => void;
+  onAddImages?: (files: File[]) => void;
 }
 
 export const TaskActions: React.FC<TaskActionsProps> = ({
@@ -29,6 +37,7 @@ export const TaskActions: React.FC<TaskActionsProps> = ({
   onRevertCompletion,
   onDelete,
   onDefer,
+  onAddImages,
 }) => {
   const { t } = useTranslation();
   const isCompleted = status === TaskStatus.COMPLETED;
@@ -39,6 +48,27 @@ export const TaskActions: React.FC<TaskActionsProps> = ({
       role="toolbar"
       aria-label={t("taskCard.taskActions")}
     >
+      {onAddImages && (
+        <>
+          <input
+            id={`img-upload-${taskId}`}
+            type="file"
+            accept="image/*"
+            multiple
+            className="hidden"
+            onChange={(e) => onAddImages(Array.from(e.target.files || []))}
+          />
+          <button
+            onClick={() =>
+              document.getElementById(`img-upload-${taskId}`)?.click()
+            }
+            className="p-2 text-gray-600 hover:text-gray-700 hover:bg-gray-50 rounded transition-colors"
+            title={t("taskCard.addImage")}
+          >
+            <ImagePlus className="w-4 h-4" />
+          </button>
+        </>
+      )}
       {/* Complete/Revert button - always visible */}
       {!isCompleted && (
         <button

--- a/src/shared/application/services/TaskImageService.ts
+++ b/src/shared/application/services/TaskImageService.ts
@@ -1,0 +1,68 @@
+import { injectable, inject } from "tsyringe";
+import { TaskImageRepository } from "../../domain/repositories/TaskImageRepository";
+import { TaskImage } from "../../domain/entities/TaskImage";
+import { rgbaToThumbHash } from "thumbhash";
+import { SupabaseClientFactory } from "../../infrastructure/database/SupabaseClient";
+import * as tokens from "../../infrastructure/di/tokens";
+
+@injectable()
+export class TaskImageService {
+  constructor(
+    @inject(tokens.TASK_IMAGE_REPOSITORY_TOKEN)
+    private repository: TaskImageRepository,
+    @inject(tokens.SUPABASE_CLIENT_FACTORY_TOKEN)
+    private supabaseFactory: SupabaseClientFactory
+  ) {}
+
+  async addImages(taskId: string, files: File[]): Promise<TaskImage[]> {
+    const images: TaskImage[] = [];
+    for (const file of files) {
+      const arrayBuffer = await file.arrayBuffer();
+      const thumbhash = await this.generateThumbhash(file);
+      const image = await this.repository.create(
+        taskId,
+        arrayBuffer,
+        thumbhash
+      );
+      images.push(image);
+      await this.saveThumbhash(taskId, image.id, thumbhash).catch(() => {});
+      // TODO: implement P2P sync for image binary data
+    }
+    return images;
+  }
+
+  async getImages(taskId: string): Promise<TaskImage[]> {
+    return this.repository.findByTaskId(taskId);
+  }
+
+  private async generateThumbhash(file: File): Promise<string> {
+    const bitmap = await createImageBitmap(file);
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d")!;
+    const width = Math.min(bitmap.width, 100);
+    const height = Math.min(bitmap.height, 100);
+    canvas.width = width;
+    canvas.height = height;
+    ctx.drawImage(bitmap, 0, 0, width, height);
+    const imageData = ctx.getImageData(0, 0, width, height);
+    const hash = rgbaToThumbHash(width, height, imageData.data);
+    return btoa(String.fromCharCode(...hash));
+  }
+
+  private async saveThumbhash(
+    taskId: string,
+    imageId: string,
+    thumbhash: string
+  ): Promise<void> {
+    try {
+      const client = this.supabaseFactory.getClient();
+      await client.from("task_images").insert({
+        id: imageId,
+        task_id: taskId,
+        thumbhash,
+      });
+    } catch {
+      // Ignore errors, supabase may be offline
+    }
+  }
+}

--- a/src/shared/domain/entities/TaskImage.ts
+++ b/src/shared/domain/entities/TaskImage.ts
@@ -1,0 +1,7 @@
+export interface TaskImage {
+  id: string;
+  taskId: string;
+  data: ArrayBuffer;
+  thumbhash: string;
+  createdAt: Date;
+}

--- a/src/shared/domain/repositories/TaskImageRepository.ts
+++ b/src/shared/domain/repositories/TaskImageRepository.ts
@@ -1,0 +1,11 @@
+import { TaskImage } from "../entities/TaskImage";
+
+export interface TaskImageRepository {
+  save(image: TaskImage): Promise<void>;
+  create(
+    taskId: string,
+    data: ArrayBuffer,
+    thumbhash: string
+  ): Promise<TaskImage>;
+  findByTaskId(taskId: string): Promise<TaskImage[]>;
+}

--- a/src/shared/infrastructure/di/container.ts
+++ b/src/shared/infrastructure/di/container.ts
@@ -7,6 +7,7 @@ import { PersistentEventBusImpl } from "../../domain/events/EventBus";
 import { TaskRepositoryImpl } from "../repositories/TaskRepositoryImpl";
 import { DailySelectionRepositoryImpl } from "../repositories/DailySelectionRepositoryImpl";
 import { TaskEventAdapter } from "../events/TaskEventAdapter";
+import { TaskImageRepositoryImpl } from "../repositories/TaskImageRepositoryImpl";
 
 // Import use cases
 import { CreateTaskUseCase } from "../../application/use-cases/CreateTaskUseCase";
@@ -23,6 +24,7 @@ import { CreateUserLogUseCase } from "../../application/use-cases/CreateUserLogU
 import { CreateSystemLogUseCase } from "../../application/use-cases/CreateSystemLogUseCase";
 import { DeferTaskUseCase } from "../../application/use-cases/DeferTaskUseCase";
 import { UndeferTaskUseCase } from "../../application/use-cases/UndeferTaskUseCase";
+import { TaskImageService } from "../../application/services/TaskImageService";
 
 // Import services
 import { DeferredTaskService } from "../../application/services/DeferredTaskService";
@@ -51,6 +53,10 @@ export function configureContainer(): void {
   container.registerSingleton(
     tokens.DAILY_SELECTION_REPOSITORY_TOKEN,
     DailySelectionRepositoryImpl
+  );
+  container.registerSingleton(
+    tokens.TASK_IMAGE_REPOSITORY_TOKEN,
+    TaskImageRepositoryImpl
   );
 
   // Register use cases as singletons
@@ -115,6 +121,10 @@ export function configureContainer(): void {
   container.registerSingleton(
     tokens.DEFERRED_TASK_SERVICE_TOKEN,
     DeferredTaskService
+  );
+  container.registerSingleton(
+    tokens.TASK_IMAGE_SERVICE_TOKEN,
+    TaskImageService
   );
 }
 

--- a/src/shared/infrastructure/di/tokens.ts
+++ b/src/shared/infrastructure/di/tokens.ts
@@ -42,6 +42,8 @@ export const DEBOUNCED_SYNC_SERVICE_TOKEN = Symbol("DebouncedSyncService");
 export const SUPABASE_REALTIME_SERVICE_TOKEN = Symbol(
   "SupabaseRealtimeService"
 );
+export const TASK_IMAGE_REPOSITORY_TOKEN = Symbol("TaskImageRepository");
+export const TASK_IMAGE_SERVICE_TOKEN = Symbol("TaskImageService");
 
 // Supabase
 export const SUPABASE_CLIENT_FACTORY_TOKEN = Symbol("SupabaseClientFactory");

--- a/src/shared/infrastructure/repositories/TaskImageRepositoryImpl.ts
+++ b/src/shared/infrastructure/repositories/TaskImageRepositoryImpl.ts
@@ -1,0 +1,35 @@
+import { injectable, inject } from "tsyringe";
+import { ulid } from "ulid";
+import { TaskImageRepository } from "../../domain/repositories/TaskImageRepository";
+import { TaskImage } from "../../domain/entities/TaskImage";
+import { TodoDatabase } from "../database/TodoDatabase";
+import * as tokens from "../di/tokens";
+
+@injectable()
+export class TaskImageRepositoryImpl implements TaskImageRepository {
+  constructor(@inject(tokens.DATABASE_TOKEN) private db: TodoDatabase) {}
+
+  async save(image: TaskImage): Promise<void> {
+    await this.db.taskImages.put(image);
+  }
+
+  async create(
+    taskId: string,
+    data: ArrayBuffer,
+    thumbhash: string
+  ): Promise<TaskImage> {
+    const image: TaskImage = {
+      id: ulid(),
+      taskId,
+      data,
+      thumbhash,
+      createdAt: new Date(),
+    };
+    await this.save(image);
+    return image;
+  }
+
+  async findByTaskId(taskId: string): Promise<TaskImage[]> {
+    return this.db.taskImages.where("taskId").equals(taskId).toArray();
+  }
+}

--- a/src/shared/ui/components/InlineTaskCreator.tsx
+++ b/src/shared/ui/components/InlineTaskCreator.tsx
@@ -3,7 +3,11 @@ import { TaskCategory } from "../../domain/types";
 import { Check } from "lucide-react";
 
 interface InlineTaskCreatorProps {
-  onCreateTask: (title: string, category: TaskCategory) => Promise<boolean>;
+  onCreateTask: (
+    title: string,
+    category: TaskCategory,
+    images?: File[]
+  ) => Promise<boolean>;
   category: TaskCategory;
   placeholder?: string;
 }
@@ -15,7 +19,10 @@ export const InlineTaskCreator: React.FC<InlineTaskCreatorProps> = ({
 }) => {
   const [title, setTitle] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [images, setImages] = useState<File[]>([]);
+  const [isDragOver, setIsDragOver] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = async () => {
     const trimmedTitle = title.trim();
@@ -23,9 +30,10 @@ export const InlineTaskCreator: React.FC<InlineTaskCreatorProps> = ({
 
     setIsSubmitting(true);
     try {
-      const success = await onCreateTask(trimmedTitle, category);
+      const success = await onCreateTask(trimmedTitle, category, images);
       if (success) {
         setTitle("");
+        setImages([]);
         if (inputRef.current) {
           inputRef.current.focus();
         }
@@ -57,13 +65,36 @@ export const InlineTaskCreator: React.FC<InlineTaskCreatorProps> = ({
 
   const handleCancel = () => {
     setTitle("");
+    setImages([]);
     if (inputRef.current) {
       inputRef.current.blur();
     }
   };
 
+  const handleFiles = (files: FileList | null) => {
+    if (!files) return;
+    const imgs = Array.from(files).filter((f) => f.type.startsWith("image/"));
+    setImages((prev) => [...prev, ...imgs]);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    handleFiles(e.dataTransfer.files);
+  };
+
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-3 shadow-sm">
+    <div
+      className={`bg-white rounded-lg border p-3 shadow-sm ${
+        isDragOver ? "border-blue-400 bg-blue-50" : "border-gray-200"
+      }`}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setIsDragOver(true);
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={handleDrop}
+    >
       <div className="flex items-center gap-2">
         <input
           ref={inputRef}
@@ -75,6 +106,22 @@ export const InlineTaskCreator: React.FC<InlineTaskCreatorProps> = ({
           disabled={isSubmitting}
           className="flex-1 text-sm border-0 focus:outline-none focus:ring-0 p-1 placeholder-gray-400"
         />
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="p-1 text-gray-600 hover:text-gray-700"
+          title="Добавить изображения"
+          type="button"
+        >
+          📷
+        </button>
         {title.trim() && (
           <button
             onClick={handleSubmit}
@@ -86,6 +133,18 @@ export const InlineTaskCreator: React.FC<InlineTaskCreatorProps> = ({
           </button>
         )}
       </div>
+      {images.length > 0 && (
+        <div className="flex gap-2 mt-2">
+          {images.map((img, idx) => (
+            <img
+              key={idx}
+              src={URL.createObjectURL(img)}
+              alt="preview"
+              className="w-12 h-12 object-cover rounded"
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add taskImages table and hooks to local Dexie database
- allow uploading images to tasks with drag and drop and previews
- save image thumbhashes via TaskImageService

## Testing
- `npm test` (fails: module not found, DI config errors)
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68957302955083338ae8cde2477e7b64