### PR TITLE
Prevent mobile task actions from triggering edit

### DIFF
--- a/src/features/tasks/presentation/components/TaskCard.tsx
+++ b/src/features/tasks/presentation/components/TaskCard.tsx
@@ -140,11 +140,6 @@ export const TaskCard: React.FC<TaskCardProps> = ({
         onAddToToday(task.id.value);
       }
     },
-    onTap: () => {
-      if (isTouch && !isEditing) {
-        handleStartEdit();
-      }
-    },
     onLongPress: () => {
       if (isTouch && onCreateLog) {
         // Long press opens log modal
@@ -243,6 +238,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
                 onRevertCompletion={onRevertCompletion}
                 onDelete={onDelete}
                 onDefer={handleOpenDeferModal}
+                onEdit={handleStartEdit}
               />
             </div>
           )}

--- a/src/features/tasks/presentation/components/task-card/TaskActions.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskActions.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { TaskStatus } from "../../../../../shared/domain/types";
 import { useTranslation } from "react-i18next";
-import { Check, Undo2, MoreHorizontal, Clock, Trash2 } from "lucide-react";
+import {
+  Check,
+  Undo2,
+  MoreHorizontal,
+  Clock,
+  Trash2,
+  Pencil,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +25,7 @@ interface TaskActionsProps {
   onRevertCompletion?: (taskId: string) => void;
   onDelete: (taskId: string) => void;
   onDefer?: () => void;
+  onEdit?: () => void;
 }
 
 export const TaskActions: React.FC<TaskActionsProps> = ({
@@ -29,6 +37,7 @@ export const TaskActions: React.FC<TaskActionsProps> = ({
   onRevertCompletion,
   onDelete,
   onDefer,
+  onEdit,
 }) => {
   const { t } = useTranslation();
   const isCompleted = status === TaskStatus.COMPLETED;
@@ -78,6 +87,15 @@ export const TaskActions: React.FC<TaskActionsProps> = ({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
+          {onEdit && (
+            <DropdownMenuItem
+              onClick={onEdit}
+              className="flex items-center gap-2"
+            >
+              <Pencil className="w-4 h-4" />
+              {t("taskCard.editTask")}
+            </DropdownMenuItem>
+          )}
           {showDeferButton && onDefer && !isCompleted && (
             <DropdownMenuItem
               onClick={onDefer}

--- a/src/shared/infrastructure/services/__tests__/useTouchGestures.test.tsx
+++ b/src/shared/infrastructure/services/__tests__/useTouchGestures.test.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { useTouchGestures } from "../useTouchGestures";
+
+beforeAll(() => {
+  class FakeTouchEvent extends Event {
+    touches: any;
+    changedTouches: any;
+    targetTouches: any;
+    constructor(type: string, params: any = {}) {
+      super(type, params);
+      this.touches = params.touches || [];
+      this.changedTouches = params.changedTouches || [];
+      this.targetTouches = params.targetTouches || [];
+    }
+  }
+  // @ts-ignore
+  global.TouchEvent = FakeTouchEvent;
+});
+
+describe("useTouchGestures", () => {
+  const setup = (onTap: () => void) => {
+    const TestComponent = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      const { attachGestures } = useTouchGestures({ onTap });
+      useEffect(() => {
+        return attachGestures(ref.current);
+      }, [attachGestures]);
+      return (
+        <div ref={ref}>
+          <button>Action</button>
+          <div data-testid="content">Content</div>
+        </div>
+      );
+    };
+    render(<TestComponent />);
+  };
+
+  it("ignores taps on interactive elements", () => {
+    const onTap = vi.fn();
+    setup(onTap);
+    const button = screen.getByText("Action");
+    fireEvent.touchStart(button, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchEnd(button, {
+      changedTouches: [{ clientX: 0, clientY: 0 }],
+    });
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it("detects taps on non-interactive elements", () => {
+    const onTap = vi.fn();
+    setup(onTap);
+    const content = screen.getByTestId("content");
+    fireEvent.touchStart(content, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchEnd(content, {
+      changedTouches: [{ clientX: 0, clientY: 0 }],
+    });
+    expect(onTap).toHaveBeenCalled();
+  });
+});

--- a/src/shared/infrastructure/services/useTouchGestures.ts
+++ b/src/shared/infrastructure/services/useTouchGestures.ts
@@ -36,9 +36,18 @@ export const useTouchGestures = (options: TouchGestureOptions = {}) => {
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [isLongPressing, setIsLongPressing] = useState(false);
 
+  const isInteractiveElement = (target: EventTarget | null): boolean => {
+    return (
+      target instanceof HTMLElement &&
+      !!target.closest(
+        "button, a, input, textarea, select, [role='button'], [aria-haspopup]"
+      )
+    );
+  };
+
   const handleTouchStart = (event: TouchEvent) => {
     const touch = event.touches[0];
-    if (!touch) return;
+    if (!touch || isInteractiveElement(event.target)) return;
 
     touchStartRef.current = {
       x: touch.clientX,
@@ -64,6 +73,11 @@ export const useTouchGestures = (options: TouchGestureOptions = {}) => {
   };
 
   const handleTouchEnd = (event: TouchEvent) => {
+    if (isInteractiveElement(event.target)) {
+      touchStartRef.current = null;
+      return;
+    }
+
     const touchStart = touchStartRef.current;
     if (!touchStart) return;
 


### PR DESCRIPTION
## Summary
- avoid starting edit mode when tapping anywhere on a task card
- add explicit Edit option to task action menu
- ignore taps on interactive elements in `useTouchGestures`
- test touch gesture hook for interactive element taps

## Testing
- `npx vitest run src/shared/infrastructure/services/__tests__/useTouchGestures.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689576cf2b00833380becccaa5d85d64