### PR TITLE
feat: restrict mobile title editing

### DIFF
--- a/src/features/tasks/presentation/components/task-card/TaskTitleDisplay.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskTitleDisplay.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TaskStatus } from "../../../../../shared/domain/types";
 import { useTranslation } from "react-i18next";
 import { Sun } from "lucide-react";
+import { getDeviceType } from "../../../../../shared/infrastructure/services/useTouchGestures";
 
 interface TaskTitleDisplayProps {
   taskId: string;
@@ -24,6 +25,7 @@ export const TaskTitleDisplay: React.FC<TaskTitleDisplayProps> = ({
 }) => {
   const { t } = useTranslation();
   const isCompleted = status === TaskStatus.COMPLETED;
+  const isMobile = getDeviceType() === "mobile";
 
   return (
     <div className="flex items-center gap-2 flex-1">
@@ -55,19 +57,26 @@ export const TaskTitleDisplay: React.FC<TaskTitleDisplayProps> = ({
       <h3
         id={`task-title-${taskId}`}
         className={`
-          text-lg font-medium text-gray-900 cursor-pointer hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded px-1 py-1 flex-1
-          ${isCompleted ? "line-through" : ""}
-        `}
-        onClick={onEdit}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onEdit();
-          }
-        }}
-        tabIndex={0}
-        role="button"
-        aria-label={t("taskCard.editTask", { title })}
+            text-lg font-medium text-gray-900 flex-1
+            ${isCompleted ? "line-through" : ""}
+            ${
+              isMobile
+                ? ""
+                : "cursor-pointer hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded px-1 py-1"
+            }
+          `}
+        {...(!isMobile && {
+          onClick: onEdit,
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onEdit();
+            }
+          },
+          tabIndex: 0,
+          role: "button",
+          "aria-label": t("taskCard.editTask", { title }),
+        })}
       >
         {title}
       </h3>

--- a/src/shared/lib/i18n.ts
+++ b/src/shared/lib/i18n.ts
@@ -95,6 +95,7 @@ const resources = {
       taskCard: {
         deferTask: "Defer Task",
         deferTaskWithTitle: "Defer task: {{title}}",
+        editTask: "Edit task",
       },
       logs: {
         actions: {
@@ -216,6 +217,7 @@ const resources = {
         overdue: "Залежалась",
         daysAgo: "Несколько дней назад",
         deleteTask: "Удалить",
+        editTask: "Редактировать",
       },
       tasks: {
         newTask: "Новая задача",


### PR DESCRIPTION
## Summary
- prevent editing a task title by tapping it on mobile; editing is now accessible only via dropdown
- add i18n key for the edit menu item in both English and Russian

## Testing
- `npm test` *(fails: 52 failing tests, 13 failed files)*

------
https://chatgpt.com/codex/tasks/task_e_68958369cb088333bb6f6b40e523c0a8