### PR TITLE
fix: refresh today task ids on new day

### DIFF
--- a/src/mvp/MVPApp.tsx
+++ b/src/mvp/MVPApp.tsx
@@ -49,6 +49,7 @@ import { toast, Toaster } from "sonner";
 import { Settings } from "../features/settings/presentation/components/Settings";
 import { ContentArea } from "./components/ContentArea";
 import { ResultUtils } from "@/shared/domain/Result";
+import { useTodayTaskIdsRefresh } from "./hooks/useTodayTaskIdsRefresh";
 
 export const MVPApp: React.FC = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -256,6 +257,9 @@ export const MVPApp: React.FC = () => {
 
     return unsubscribe;
   }, [loadTodayTaskIds]);
+
+  // Refresh todayTaskIds when the calendar day changes
+  useTodayTaskIdsRefresh(loadTodayTaskIds);
 
   // Register keyboard shortcuts
   useEffect(() => {

--- a/src/mvp/hooks/__tests__/useTodayTaskIdsRefresh.test.ts
+++ b/src/mvp/hooks/__tests__/useTodayTaskIdsRefresh.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi } from "vitest";
+import { useTodayTaskIdsRefresh } from "../useTodayTaskIdsRefresh";
+import { DateOnly } from "../../../shared/domain/value-objects/DateOnly";
+
+describe("useTodayTaskIdsRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.removeItem("__dev_mocked_date__");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.removeItem("__dev_mocked_date__");
+  });
+
+  it("calls refresh when the day changes", async () => {
+    const refresh = vi.fn();
+    const today = DateOnly.fromString("2024-01-01");
+    const tomorrow = DateOnly.fromString("2024-01-02");
+    const spy = vi
+      .spyOn(DateOnly, "today")
+      .mockReturnValueOnce(today)
+      .mockReturnValue(tomorrow);
+
+    renderHook(() => useTodayTaskIdsRefresh(refresh));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(refresh).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+

--- a/src/mvp/hooks/useTodayTaskIdsRefresh.ts
+++ b/src/mvp/hooks/useTodayTaskIdsRefresh.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { DateOnly } from "../../shared/domain/value-objects/DateOnly";
+
+/**
+ * Hook that refreshes today task IDs when the day changes.
+ *
+ * @param refresh Function that reloads today task IDs
+ */
+export const useTodayTaskIdsRefresh = (
+  refresh: () => Promise<void>
+): void => {
+  useEffect(() => {
+    let lastDate = DateOnly.today().value;
+
+    const checkForDayChange = async () => {
+      const currentDate = DateOnly.today().value;
+      if (currentDate !== lastDate) {
+        lastDate = currentDate;
+        await refresh();
+      }
+    };
+
+    const interval = setInterval(checkForDayChange, 60_000); // every minute
+    return () => clearInterval(interval);
+  }, [refresh]);
+};
+


### PR DESCRIPTION
## Summary
- refresh today's task selection when calendar day changes
- add hook and test for automatic today task id refresh

## Testing
- `npm test` *(fails: missing Supabase environment variables)*
- `npx vitest run src/mvp/hooks/__tests__/useTodayTaskIdsRefresh.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b14767c6c8333bee789b4fe16eae6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Today list now auto-refreshes when the calendar day changes, keeping tasks current at midnight without manual action or app reload. This works alongside existing real-time updates for add/remove/delete, improving reliability for daily planning.

* **Tests**
  * Added unit tests to confirm the day-change trigger correctly refreshes Today tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->