### PR TITLE
feat: add master device reservation for background tasks

### DIFF
--- a/src/shared/infrastructure/database/supabase-types.ts
+++ b/src/shared/infrastructure/database/supabase-types.ts
@@ -119,6 +119,30 @@ export type Database = {
         };
         Relationships: [];
       };
+      master_devices: {
+        Row: {
+          created_at: string;
+          device_id: string;
+          expires_at: string;
+          id: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          device_id: string;
+          expires_at: string;
+          id?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          device_id?: string;
+          expires_at?: string;
+          id?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       task_logs: {
         Row: {
           action: string;

--- a/src/shared/infrastructure/di/syncContainer.ts
+++ b/src/shared/infrastructure/di/syncContainer.ts
@@ -4,6 +4,7 @@ import { SupabaseSyncRepository } from "../repositories/SupabaseSyncRepository";
 import { SyncService } from "../../application/services/SyncService";
 import { DebouncedSyncService } from "../../application/services/DebouncedSyncService";
 import { SupabaseRealtimeService } from "../services/SupabaseRealtimeService";
+import { MasterDeviceService } from "../services/MasterDeviceService";
 import {
   getSupabaseConfig,
   validateSupabaseConfig,
@@ -52,6 +53,12 @@ export function configureSyncContainer(): void {
       SupabaseRealtimeService
     );
 
+    // Register master device service
+    container.registerSingleton(
+      tokens.MASTER_DEVICE_SERVICE_TOKEN,
+      MasterDeviceService
+    );
+
     console.log("Sync container configured successfully");
   } catch (error) {
     console.error("Failed to configure sync container:", error);
@@ -72,6 +79,15 @@ export function getSyncService(): SyncService {
 export function getRealtimeService(): SupabaseRealtimeService {
   return container.resolve<SupabaseRealtimeService>(
     tokens.SUPABASE_REALTIME_SERVICE_TOKEN
+  );
+}
+
+/**
+ * Gets master device service from container
+ */
+export function getMasterDeviceService(): MasterDeviceService {
+  return container.resolve<MasterDeviceService>(
+    tokens.MASTER_DEVICE_SERVICE_TOKEN
   );
 }
 

--- a/src/shared/infrastructure/di/tokens.ts
+++ b/src/shared/infrastructure/di/tokens.ts
@@ -43,6 +43,7 @@ export const DEBOUNCED_SYNC_SERVICE_TOKEN = Symbol("DebouncedSyncService");
 export const SUPABASE_REALTIME_SERVICE_TOKEN = Symbol(
   "SupabaseRealtimeService"
 );
+export const MASTER_DEVICE_SERVICE_TOKEN = Symbol("MasterDeviceService");
 
 // Supabase
 export const SUPABASE_CLIENT_FACTORY_TOKEN = Symbol("SupabaseClientFactory");

--- a/src/shared/infrastructure/services/MasterDeviceService.ts
+++ b/src/shared/infrastructure/services/MasterDeviceService.ts
@@ -1,0 +1,145 @@
+import { injectable, inject } from "tsyringe";
+import { SupabaseClient } from "@supabase/supabase-js";
+import {
+  SupabaseClientFactory,
+  Database,
+  SupabaseUtils,
+} from "../database/SupabaseClient";
+import * as tokens from "../di/tokens";
+
+/**
+ * Service that coordinates master device reservation so that only one device
+ * performs background actions for a user. A device acquires the master role if
+ * no active master exists or if the previous reservation expired. The role is
+ * reserved for 30 minutes and automatically extended when the master checks in.
+ */
+@injectable()
+export class MasterDeviceService {
+  private readonly RESERVATION_MS = 30 * 60 * 1000; // 30 minutes
+  private client: SupabaseClient<Database>;
+  private deviceId: string;
+  private userId: string | null = null;
+
+  constructor(
+    @inject(tokens.SUPABASE_CLIENT_FACTORY_TOKEN)
+    clientFactory: SupabaseClientFactory
+  ) {
+    this.client = clientFactory.getClient();
+    this.deviceId = SupabaseUtils.getDeviceId();
+    this.initializeUserId();
+  }
+
+  private async initializeUserId(): Promise<void> {
+    this.userId = await SupabaseUtils.getUserId(this.client);
+  }
+
+  /**
+     * Try to acquire or renew the master role for this device.
+     * Returns true when this device becomes (or already is) the master.
+     */
+  async acquireMaster(): Promise<boolean> {
+    if (!this.userId) {
+      await this.initializeUserId();
+    }
+    if (!this.userId) return false;
+
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const newExpiry = new Date(now.getTime() + this.RESERVATION_MS).toISOString();
+
+    // Check current master record
+    const { data: existing, error: selectError } = await this.client
+      .from("master_devices")
+      .select("device_id, expires_at")
+      .eq("user_id", this.userId)
+      .single();
+
+    if (selectError && selectError.code !== "PGRST116") {
+      // PGRST116 means no rows; other errors we treat as failure
+      console.error("Failed to check master device:", selectError);
+      return false;
+    }
+
+    if (existing) {
+      const expiresAt = new Date(existing.expires_at);
+      if (existing.device_id === this.deviceId && expiresAt > now) {
+        // We are already master; extend reservation
+        await this.client
+          .from("master_devices")
+          .update({ expires_at: newExpiry })
+          .eq("user_id", this.userId);
+        return true;
+      }
+      if (expiresAt > now) {
+        // Another active master
+        return false;
+      }
+      // Reservation expired -> attempt to take over
+      const { data: updated, error: updateError } = await this.client
+        .from("master_devices")
+        .update({ device_id: this.deviceId, expires_at: newExpiry })
+        .eq("user_id", this.userId)
+        .lte("expires_at", nowIso)
+        .select();
+
+      if (!updateError && updated && updated.length > 0) {
+        return true;
+      }
+      // If update fails (e.g., because record changed), fallback to insert
+    }
+
+    // Try to insert new master record
+    const { error: insertError } = await this.client
+      .from("master_devices")
+      .insert({
+        user_id: this.userId,
+        device_id: this.deviceId,
+        expires_at: newExpiry,
+      });
+
+    if (insertError) {
+      // Duplicate key means someone else became master simultaneously
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Checks if this device currently holds the master role.
+   */
+  async isMaster(): Promise<boolean> {
+    if (!this.userId) {
+      await this.initializeUserId();
+    }
+    if (!this.userId) return false;
+
+    const { data, error } = await this.client
+      .from("master_devices")
+      .select("device_id, expires_at")
+      .eq("user_id", this.userId)
+      .single();
+
+    if (error || !data) return false;
+
+    return (
+      data.device_id === this.deviceId &&
+      new Date(data.expires_at) > new Date()
+    );
+  }
+
+  /**
+   * Releases master role if this device holds it.
+   */
+  async release(): Promise<void> {
+    if (!this.userId) {
+      await this.initializeUserId();
+    }
+    if (!this.userId) return;
+
+    await this.client
+      .from("master_devices")
+      .delete()
+      .eq("user_id", this.userId)
+      .eq("device_id", this.deviceId);
+  }
+}

--- a/supabase/migrations/20250901000000_create_master_devices_table.sql
+++ b/supabase/migrations/20250901000000_create_master_devices_table.sql
@@ -1,0 +1,20 @@
+-- Миграция: создание таблицы master_devices для бронирования роли мастера
+
+CREATE TABLE master_devices (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    device_id TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id)
+);
+
+-- Включаем RLS
+ALTER TABLE master_devices ENABLE ROW LEVEL SECURITY;
+
+-- Политика: пользователи могут управлять только своей записью мастера
+CREATE POLICY "Users can manage their master record" ON master_devices
+    FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Индекс для быстрого поиска по времени истечения
+CREATE INDEX idx_master_devices_expires_at ON master_devices(expires_at);


### PR DESCRIPTION
## Summary
- add `master_devices` table to track master role
- introduce `MasterDeviceService` and DI wiring
- integrate master acquisition into sync initializer

## Testing
- `npm test` *(fails: Отсутствуют обязательные переменные окружения для Supabase. Убедитесь, что VITE_SUPABASE_URL и VITE_SUPABASE_ANON_KEY установлены., expected error codes mismatch, container dependency errors, and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689bc23272f48333b69fc30f176279f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Per-user “master device” coordination to run background sync and scheduled tasks on a single device, reducing duplicates and conflicts.
  * Automatic lease renewal and safe handover between devices after ~30 minutes of inactivity.
  * More reliable processing of deferred tasks following each sync, improving overall stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->