### PR TITLE
style: make task card badges more compact

### DIFF
--- a/src/features/tasks/presentation/components/task-card/TaskCardHeader.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskCardHeader.tsx
@@ -45,22 +45,22 @@ export const TaskCardHeader: React.FC<TaskCardHeaderProps> = ({
   const CategoryIcon = getCategoryIcon(category);
 
   return (
-    <div className="flex items-center gap-2 mb-1">
+    <div className="flex items-center gap-1 mb-1">
       {/* Only show category badge if not on the same category page */}
       {currentCategory !== category && (
         <span
           className={`
-            inline-flex items-center px-2 py-1 rounded-full text-xs font-medium border
+            inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium border
             ${categoryColor}
           `}
         >
-          <CategoryIcon className="w-3 h-3 mr-1" />
+          <CategoryIcon className="w-2.5 h-2.5 mr-1" />
           {t(`categories.${category.toLowerCase()}`)}
         </span>
       )}
       {isOverdue && (
-        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 border border-red-200">
-          <AlertTriangle className="w-3 h-3 mr-1" />
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-red-100 text-red-800 border border-red-200">
+          <AlertTriangle className="w-2.5 h-2.5 mr-1" />
           {t("taskCard.overdue")}
         </span>
       )}


### PR DESCRIPTION
## Summary
- shrink category and overdue badges in task cards with reduced padding and smaller text

## Testing
- `npm test` *(fails: missing Supabase env variables and other test issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a30238db648333809dda2c1ff1976f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Made the Task Card header more compact by reducing horizontal spacing.
  * Shrunk the category and overdue badges (padding, text, and icon sizes) for a lighter visual footprint.
  * Improves readability and density, allowing more content to fit without overwhelming the layout.
  * No behavioral changes; visual presentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->