### PR TITLE
chore: reduce task card title size

### DIFF
--- a/src/features/tasks/presentation/components/DeferredTaskCard.tsx
+++ b/src/features/tasks/presentation/components/DeferredTaskCard.tsx
@@ -42,7 +42,9 @@ export const DeferredTaskCard: React.FC<DeferredTaskCardProps> = ({
     >
       <div className="flex items-start justify-between">
         <div className="flex-1">
-          <h3 className="font-medium text-gray-900 mb-2">{task.title.value}</h3>
+          <h3 className="text-sm leading-snug font-medium text-gray-900 mb-2">
+            {task.title.value}
+          </h3>
 
           <div className="flex items-center text-sm text-gray-600 mb-3">
             <Clock className="w-4 h-4 mr-1" />

--- a/src/features/tasks/presentation/components/task-card/TaskTitleDisplay.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskTitleDisplay.tsx
@@ -57,12 +57,12 @@ export const TaskTitleDisplay: React.FC<TaskTitleDisplayProps> = ({
       <h3
         id={`task-title-${taskId}`}
         className={`
-            text-lg font-medium text-gray-900 flex-1
+            text-sm leading-snug font-medium text-gray-900 flex-1
             ${isCompleted ? "line-through" : ""}
             ${
               isMobile
                 ? ""
-                : "cursor-pointer hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded px-1 py-1"
+                : "cursor-pointer hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded px-1 py-0.5"
             }
           `}
         {...(!isMobile && {

--- a/src/features/tasks/presentation/components/task-card/TaskTitleEditor.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskTitleEditor.tsx
@@ -51,7 +51,7 @@ export const TaskTitleEditor: React.FC<TaskTitleEditorProps> = ({
         value={title}
         onChange={(e) => onTitleChange(e.target.value)}
         onKeyDown={handleKeyDown}
-        className="flex-1 text-lg font-medium text-gray-900 bg-white border border-blue-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        className="flex-1 text-sm leading-snug font-medium text-gray-900 bg-white border border-blue-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
         maxLength={200}
       />
       <button


### PR DESCRIPTION
## Summary
- shrink task titles and tighten line spacing in task cards
- apply smaller title styling for deferred task cards

## Testing
- `npm test` *(fails: missing Supabase environment variables and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a40adfb4448333a9d63e5a4c970e33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted task title typography to a smaller font size with tighter line height across task cards and editors for a more compact display.
  * Updated DeferredTaskCard and TaskTitleDisplay titles to use text-sm and leading-snug while preserving existing weight and color.
  * Reduced non-mobile vertical padding in TaskTitleDisplay (from py-1 to py-0.5) to align spacing with the new typography.
  * Updated TaskTitleEditor input styling to match the new text size and line height without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->