### PR TITLE
Auto-return due deferred tasks during start-of-day transition

### DIFF
--- a/src/features/onboarding/application/services/OnboardingService.ts
+++ b/src/features/onboarding/application/services/OnboardingService.ts
@@ -12,6 +12,7 @@ import { CreateSystemLogUseCase } from "../../../../shared/application/use-cases
 import { EventBus } from "../../../../shared/domain/events/EventBus";
 import { container, tokens } from "../../../../shared/infrastructure/di";
 import i18n from "../../../../shared/lib/i18n";
+import { UndeferTaskUseCase } from "../../../../shared/application/use-cases/UndeferTaskUseCase";
 
 /**
  * Data aggregated for the daily modal
@@ -179,6 +180,10 @@ export class OnboardingService {
    */
   async getDueDeferredTasks(): Promise<Task[]> {
     const today = await this.getEffectiveDate();
+    return this.getDueDeferredTasksForDate(today);
+  }
+
+  private async getDueDeferredTasksForDate(date: DateOnly): Promise<Task[]> {
     const deferredTasks = await this.taskRepository.findByCategoryAndStatus(
       TaskCategory.DEFERRED,
       TaskStatus.ACTIVE
@@ -187,7 +192,7 @@ export class OnboardingService {
     return deferredTasks.filter((task) => {
       if (!task.deferredUntil) return false;
       const deferredDate = DateOnly.fromDate(task.deferredUntil);
-      return deferredDate.value === today.value;
+      return deferredDate.value === date.value;
     });
   }
 
@@ -282,14 +287,39 @@ export class OnboardingService {
   /**
    * Handle new day transition - clear previous day's selection
    */
-  async handleNewDayTransition(): Promise<void> {
+  async handleNewDayTransition(effectiveDate?: DateOnly): Promise<void> {
     try {
-      await this.dailySelectionService.clearTodaySelection();
+      const targetDate = effectiveDate ?? (await this.getEffectiveDate());
+      await this.dailySelectionService.clearSelectionForDate(targetDate);
+
+      // Automatically return deferred tasks that are due on the effective day
+      const dueDeferredTasks = await this.getDueDeferredTasksForDate(targetDate);
+      if (dueDeferredTasks.length > 0) {
+        const undeferTaskUseCase = container.resolve<UndeferTaskUseCase>(
+          tokens.UNDEFER_TASK_USE_CASE_TOKEN
+        );
+
+        for (const task of dueDeferredTasks) {
+          const result = await undeferTaskUseCase.execute({
+            taskId: task.id.value,
+          });
+
+          if (!result.success) {
+            console.error(
+              `Failed to auto-undefer task ${task.id.value}:`,
+              result.error
+            );
+          }
+        }
+      }
 
       await this.createSystemLogUseCase.execute({
         taskId: "system",
         action: "new_day_transition",
-        metadata: { date: DateOnly.today().value },
+        metadata: {
+          date: targetDate.value,
+          dueDeferredReturned: dueDeferredTasks.length,
+        },
       });
     } catch (error) {
       console.error("Error handling new day transition:", error);

--- a/src/features/onboarding/domain/services/DailySelectionService.ts
+++ b/src/features/onboarding/domain/services/DailySelectionService.ts
@@ -114,17 +114,24 @@ export class DailySelectionService {
    * This should be called when a new day starts
    */
   async clearTodaySelection(): Promise<void> {
+    await this.clearSelectionForDate(DateOnly.today());
+  }
+
+  /**
+   * Clear all selections for a specific effective day
+   * This should be used by start-of-day transition logic that respects user settings.
+   */
+  async clearSelectionForDate(date: DateOnly): Promise<void> {
     try {
-      const today = DateOnly.today();
-      await this.dailySelectionRepository.clearDay(today);
+      await this.dailySelectionRepository.clearDay(date);
 
       await this.createSystemLogUseCase.execute({
         taskId: "system",
         action: "daily_selection_cleared",
-        metadata: { date: today.value },
+        metadata: { date: date.value },
       });
 
-      console.log("Daily selection cleared for today");
+      console.log("Daily selection cleared for date:", date.value);
     } catch (error) {
       console.error("Error clearing daily selection:", error);
       throw error;

--- a/src/features/onboarding/presentation/view-models/OnboardingViewModel.ts
+++ b/src/features/onboarding/presentation/view-models/OnboardingViewModel.ts
@@ -246,6 +246,8 @@ export const useOnboardingViewModel = create<OnboardingState>((set, get) => {
       const today = getEffectiveDateValue(state.startOfDayTime);
 
       if (state.currentDay !== today) {
+        const transitionedDate = DateOnly.fromString(today);
+        void onboardingService.handleNewDayTransition(transitionedDate);
         // Day has changed, reset for new day but preserve modal data if modal is visible
         get().resetForNewDay(state.isModalVisible);
         return true;


### PR DESCRIPTION
## Summary
- wired deferred-task return into the existing new-day transition flow
- made daily selection clearing date-aware so it can use the effective day derived from start-of-day settings
- triggered the new-day transition handler from onboarding day-change detection

## What changed
- `OnboardingService.handleNewDayTransition` now:
  - accepts an optional effective date
  - clears daily selection for that effective date
  - auto-undefer tasks whose `deferredUntil` matches the effective date
  - logs how many deferred tasks were auto-returned
- `DailySelectionService` now provides `clearSelectionForDate(date)` and `clearTodaySelection()` delegates to it.
- `OnboardingViewModel.checkDayTransition` now calls `onboardingService.handleNewDayTransition(...)` when effective day changes.

## Why
Previously deferred tasks due on a given day were shown in the morning modal but stayed in the Deferred category until manual action. This change restores them automatically at start-of-day, aligned with the same effective-day boundary used by user start-of-day settings and daily reset logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86b2a405883339ce01f378a7931c8)