### PR TITLE
Stop click bubbling from task status/log so edit modal doesn't open

### DIFF
--- a/src/features/tasks/presentation/components/task-card/TaskLogsDisplay.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskLogsDisplay.tsx
@@ -17,6 +17,10 @@ export const TaskLogsDisplay: React.FC<TaskLogsDisplayProps> = ({
 }) => {
   const { t, i18n } = useTranslation();
   const now = useCurrentTime();
+  const handleOpenLogModal = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    onToggleLogHistory();
+  };
 
   if (!lastLog && !onCreateLog) {
     return null;
@@ -29,7 +33,8 @@ export const TaskLogsDisplay: React.FC<TaskLogsDisplayProps> = ({
         {lastLog ? (
           <div
             className="cursor-pointer hover:text-gray-700 transition-colors"
-            onClick={onToggleLogHistory}
+            onClick={handleOpenLogModal}
+            data-no-card-edit
           >
             {t("taskCard.lastLog")} {lastLog.message} (
             {formatTimeAgo(lastLog.createdAt, now, t, i18n.language)})
@@ -37,7 +42,8 @@ export const TaskLogsDisplay: React.FC<TaskLogsDisplayProps> = ({
         ) : (
           <div
             className="cursor-pointer hover:text-gray-700 transition-colors"
-            onClick={onToggleLogHistory}
+            onClick={handleOpenLogModal}
+            data-no-card-edit
           >
             {t("taskCard.noLogsYet")}
           </div>


### PR DESCRIPTION
### Motivation
- Clicking the status/log area on a task card currently triggers both the status/log modal and the task edit modal due to event bubbling, and it should only open the status/log modal.

### Description
- Add a `handleOpenLogModal` handler that calls `event.stopPropagation()` and then invokes `onToggleLogHistory` to prevent the card-level click handler from running when the status/log area is clicked.
- Mark the clickable log rows with `data-no-card-edit` so they are explicitly excluded from the card edit-open logic.

### Testing
- Ran `npm test -- src/features/tasks/presentation/components/__tests__/TaskCard.test.tsx`, which executed the test runner but the tests in this file were skipped in the environment due to missing Supabase environment variables (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`).
- No automated test failures related to this change were observed in the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8721fb9dc8333af09444cc9b8b348)