### PR TITLE
Улучшение истории активности: компактные записи и логирование отложенных/возвращённых задач

### DIFF
--- a/src/features/logs/presentation/components/TaskLogList.tsx
+++ b/src/features/logs/presentation/components/TaskLogList.tsx
@@ -1,9 +1,21 @@
 import React from "react";
-import { Settings, User, AlertTriangle, FileText, Loader2 } from "lucide-react";
+import {
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  FileText,
+  FolderSync,
+  Loader2,
+  PencilLine,
+  Settings,
+  Undo2,
+  User,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useCurrentTime } from "@/shared/presentation/contexts/CurrentTimeContext";
 import { formatTimeAgo } from "@/shared/utils/timeFormat";
 import { LogEntry } from "../../../../shared/application/use-cases/GetTaskLogsUseCase";
+import { DomainEventType } from "../../../../shared/domain/types";
 
 interface TaskLogListProps {
   logs: LogEntry[];
@@ -28,19 +40,56 @@ const getLogTypeIcon = (type: "SYSTEM" | "USER" | "CONFLICT") => {
   }
 };
 
-const getLogTypeColor = (type: "SYSTEM" | "USER" | "CONFLICT"): string => {
-  switch (type) {
-    case "SYSTEM":
-      return "bg-blue-100 text-blue-800";
-    case "USER":
-      return "bg-green-100 text-green-800";
-    case "CONFLICT":
-      return "bg-red-100 text-red-800";
-    default:
-      return "bg-gray-100 text-gray-800";
+const getLogActionVisual = (
+  log: LogEntry
+): { Icon: React.ComponentType<{ className?: string }>; className: string } => {
+  const eventType = log.metadata?.eventType as DomainEventType | undefined;
+
+  if (eventType === DomainEventType.TASK_COMPLETED) {
+    return { Icon: CheckCircle2, className: "text-emerald-600" };
   }
+  if (eventType === DomainEventType.TASK_DEFERRED) {
+    return { Icon: CalendarClock, className: "text-amber-600" };
+  }
+  if (eventType === DomainEventType.TASK_UNDEFERRED) {
+    return { Icon: Undo2, className: "text-indigo-600" };
+  }
+  if (eventType === DomainEventType.TASK_TITLE_CHANGED) {
+    return { Icon: PencilLine, className: "text-violet-600" };
+  }
+  if (eventType === DomainEventType.TASK_CATEGORY_CHANGED) {
+    return { Icon: FolderSync, className: "text-sky-600" };
+  }
+
+  return {
+    Icon: getLogTypeIcon(log.type),
+    className:
+      log.type === "SYSTEM"
+        ? "text-blue-600"
+        : log.type === "USER"
+          ? "text-green-600"
+          : "text-red-600",
+  };
 };
 
+const getLogActionKey = (log: LogEntry): string => {
+  const eventType = log.metadata?.eventType as DomainEventType | undefined;
+
+  switch (eventType) {
+    case DomainEventType.TASK_COMPLETED:
+      return "completed";
+    case DomainEventType.TASK_DEFERRED:
+      return "deferred";
+    case DomainEventType.TASK_UNDEFERRED:
+      return "undeferred";
+    case DomainEventType.TASK_TITLE_CHANGED:
+      return "title_changed";
+    case DomainEventType.TASK_CATEGORY_CHANGED:
+      return "status_changed";
+    default:
+      return log.type.toLowerCase();
+  }
+};
 
 const formatMetadata = (
   metadata?: Record<string, any>,
@@ -136,60 +185,58 @@ export const TaskLogList: React.FC<TaskLogListProps> = ({
     <div className="space-y-4">
       {/* Log entries */}
       <div className="space-y-3">
-        {logs.map((log) => (
-          <div
-            key={log.id}
-            className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-shadow"
-          >
-            <div className="flex items-start justify-between">
-              <div className="flex items-start space-x-3 flex-1">
-                {/* Log type indicator */}
-                <div className="flex-shrink-0">
-                  {React.createElement(getLogTypeIcon(log.type), {
-                    className: "w-5 h-5 text-gray-600",
-                  })}
-                </div>
-
-                <div className="flex-1 min-w-0">
-                  {/* Header with type and timestamp */}
-                  <div className="flex items-center space-x-2 mb-2">
-                    <span
-                      className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getLogTypeColor(
-                        log.type
-                      )}`}
-                    >
-                      {log.type}
-                    </span>
-                    {showTaskId && log.taskId && (
-                      <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
-                        {t("logs.task")}: {log.taskId.slice(-8)}
-                      </span>
-                    )}
-                    <span className="text-sm text-gray-500">
-                      {formatTimeAgo(log.createdAt, now, t, i18n.language)}
-                    </span>
+        {logs.map((log) => {
+          const { Icon, className } = getLogActionVisual(log);
+          const actionKey = getLogActionKey(log);
+          return (
+            <div
+              key={log.id}
+              className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-shadow"
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex items-start space-x-3 flex-1">
+                  {/* Action indicator */}
+                  <div className="flex-shrink-0">
+                    <Icon
+                      className={`w-5 h-5 ${className}`}
+                      data-testid={`history-action-icon-${actionKey}`}
+                    />
                   </div>
 
-                  {/* Log message */}
-                  <p className="text-gray-900 text-sm leading-relaxed">
-                    {log.message}
-                  </p>
-
-                  {/* Metadata */}
-                  {log.metadata && (
-                    <div className="mt-2">
-                      {formatMetadata(log.metadata, t) && (
-                        <p className="text-xs text-gray-600 bg-gray-50 rounded px-2 py-1">
-                          {formatMetadata(log.metadata, t)}
-                        </p>
+                  <div className="flex-1 min-w-0">
+                    {/* Header with contextual chips and timestamp */}
+                    <div className="flex items-center gap-2 mb-2 flex-wrap">
+                      {showTaskId && log.taskId && (
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                          {t("logs.task")}: {log.taskId.slice(-8)}
+                        </span>
                       )}
+                      <span className="text-sm text-gray-500">
+                        {formatTimeAgo(log.createdAt, now, t, i18n.language)}
+                      </span>
                     </div>
-                  )}
+
+                    {/* Log message */}
+                    <p className="text-gray-900 text-sm leading-relaxed">
+                      {log.message}
+                    </p>
+
+                    {/* Metadata */}
+                    {log.metadata && (
+                      <div className="mt-2">
+                        {formatMetadata(log.metadata, t) && (
+                          <p className="text-xs text-gray-600 bg-gray-50 rounded px-2 py-1">
+                            {formatMetadata(log.metadata, t)}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Load more button */}

--- a/src/features/logs/presentation/components/__tests__/TaskLogList.test.tsx
+++ b/src/features/logs/presentation/components/__tests__/TaskLogList.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TaskLogList } from "../TaskLogList";
+import { DomainEventType } from "../../../../../shared/domain/types";
+import { LogEntry } from "../../../../../shared/application/use-cases/GetTaskLogsUseCase";
+
+const logs: LogEntry[] = [
+  {
+    id: 1,
+    taskId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    type: "SYSTEM",
+    message: "Task completed in SIMPLE category",
+    metadata: { eventType: DomainEventType.TASK_COMPLETED },
+    createdAt: new Date("2026-04-25T10:00:00Z"),
+  },
+  {
+    id: 2,
+    taskId: "01ARZ3NDEKTSV4RRFFQ69G5FBW",
+    type: "SYSTEM",
+    message: "Task deferred until 2026-04-30",
+    metadata: { eventType: DomainEventType.TASK_DEFERRED },
+    createdAt: new Date("2026-04-25T10:05:00Z"),
+  },
+  {
+    id: 3,
+    taskId: "01ARZ3NDEKTSV4RRFFQ69G5FCX",
+    type: "SYSTEM",
+    message: "Task returned from deferred",
+    metadata: { eventType: DomainEventType.TASK_UNDEFERRED },
+    createdAt: new Date("2026-04-25T10:10:00Z"),
+  },
+  {
+    id: 4,
+    taskId: "01ARZ3NDEKTSV4RRFFQ69G5FDY",
+    type: "SYSTEM",
+    message: 'Task title changed from "A" to "B"',
+    metadata: { eventType: DomainEventType.TASK_TITLE_CHANGED },
+    createdAt: new Date("2026-04-25T10:15:00Z"),
+  },
+];
+
+describe("TaskLogList", () => {
+  it("renders action icons for history events", () => {
+    render(<TaskLogList logs={logs} showTaskId={true} />);
+
+    expect(
+      screen.getByTestId("history-action-icon-completed")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("history-action-icon-deferred")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("history-action-icon-undeferred")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("history-action-icon-title_changed")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render technical type labels", () => {
+    render(<TaskLogList logs={logs} showTaskId={true} />);
+
+    expect(screen.queryByText("SYSTEM")).not.toBeInTheDocument();
+    expect(screen.queryByText("USER")).not.toBeInTheDocument();
+    expect(screen.queryByText("CONFLICT")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/stats/application/event-handlers/TaskLogEventHandler.ts
+++ b/src/features/stats/application/event-handlers/TaskLogEventHandler.ts
@@ -8,6 +8,8 @@ import {
   TaskTitleChangedEvent,
   TaskSoftDeletedEvent,
   TaskNoteChangedEvent,
+  TaskDeferredEvent,
+  TaskUndeferredEvent,
 } from "../../../../shared/domain/events/TaskEvents";
 import { TodoDatabase } from "../../../../shared/infrastructure/database/TodoDatabase";
 import { DomainEventType } from "../../../../shared/domain/types";
@@ -53,6 +55,12 @@ export class TaskLogEventHandler implements EventHandler {
         break;
       case DomainEventType.TASK_SOFT_DELETED:
         await this.handleTaskSoftDeleted(event as TaskSoftDeletedEvent);
+        break;
+      case DomainEventType.TASK_DEFERRED:
+        await this.handleTaskDeferred(event as TaskDeferredEvent);
+        break;
+      case DomainEventType.TASK_UNDEFERRED:
+        await this.handleTaskUndeferred(event as TaskUndeferredEvent);
         break;
     }
   }
@@ -202,6 +210,39 @@ export class TaskLogEventHandler implements EventHandler {
       metadata: {
         eventType: event.eventType,
         deletedAt: event.deletedAt.toISOString(),
+      },
+      createdAt: new Date(event.createdAt),
+    });
+  }
+
+  private async handleTaskDeferred(event: TaskDeferredEvent): Promise<void> {
+    const logId = `task-deferred-${event.aggregateId}-${event.createdAt}`;
+
+    await this.database.taskLogs.put({
+      id: logId,
+      taskId: event.taskId.value,
+      type: "SYSTEM",
+      message: `Task deferred until ${event.deferredUntil.toISOString().slice(0, 10)}`,
+      metadata: {
+        eventType: event.eventType,
+        deferredUntil: event.deferredUntil.toISOString(),
+      },
+      createdAt: new Date(event.createdAt),
+    });
+  }
+
+  private async handleTaskUndeferred(
+    event: TaskUndeferredEvent
+  ): Promise<void> {
+    const logId = `task-undeferred-${event.aggregateId}-${event.createdAt}`;
+
+    await this.database.taskLogs.put({
+      id: logId,
+      taskId: event.taskId.value,
+      type: "SYSTEM",
+      message: "Task returned from deferred",
+      metadata: {
+        eventType: event.eventType,
       },
       createdAt: new Date(event.createdAt),
     });

--- a/src/features/stats/application/event-handlers/__tests__/TaskLogEventHandler.test.ts
+++ b/src/features/stats/application/event-handlers/__tests__/TaskLogEventHandler.test.ts
@@ -7,6 +7,9 @@ import {
   TaskCategoryChangedEvent,
   TaskReviewedEvent,
   TaskNoteChangedEvent,
+  TaskTitleChangedEvent,
+  TaskDeferredEvent,
+  TaskUndeferredEvent,
 } from "../../../../../shared/domain/events/TaskEvents";
 import { TaskId } from "../../../../../shared/domain/value-objects/TaskId";
 import { NonEmptyTitle } from "../../../../../shared/domain/value-objects/NonEmptyTitle";
@@ -97,6 +100,30 @@ describe("TaskLogEventHandler", () => {
     });
   });
 
+  describe("handleTaskTitleChanged", () => {
+    it("should create system log for title change", async () => {
+      const taskId = TaskId.generate();
+      const fromTitle = NonEmptyTitle.fromString("Old title");
+      const toTitle = NonEmptyTitle.fromString("New title");
+      const event = new TaskTitleChangedEvent(taskId, fromTitle, toTitle);
+
+      await handler.handle(event);
+
+      expect(mockDatabase.taskLogs.put).toHaveBeenCalledWith({
+        id: `task-title-changed-${event.aggregateId}-${event.createdAt}`,
+        taskId: taskId.value,
+        type: "SYSTEM",
+        message: 'Task title changed from "Old title" to "New title"',
+        metadata: {
+          eventType: event.eventType,
+          fromTitle: "Old title",
+          toTitle: "New title",
+        },
+        createdAt: new Date(event.createdAt),
+      });
+    });
+  });
+
   describe("handleTaskReviewed", () => {
     it("should create system log for task review", async () => {
       const taskId = TaskId.generate();
@@ -175,6 +202,46 @@ describe("TaskLogEventHandler", () => {
           eventType: event.eventType,
           fromNote: "Old note",
           toNote: "New note",
+        },
+        createdAt: new Date(event.createdAt),
+      });
+    });
+  });
+
+  describe("deferred lifecycle logs", () => {
+    it("should create system log for task defer", async () => {
+      const taskId = TaskId.generate();
+      const deferredUntil = new Date("2026-05-02T00:00:00.000Z");
+      const event = new TaskDeferredEvent(taskId, deferredUntil);
+
+      await handler.handle(event);
+
+      expect(mockDatabase.taskLogs.put).toHaveBeenCalledWith({
+        id: `task-deferred-${event.aggregateId}-${event.createdAt}`,
+        taskId: taskId.value,
+        type: "SYSTEM",
+        message: "Task deferred until 2026-05-02",
+        metadata: {
+          eventType: event.eventType,
+          deferredUntil: deferredUntil.toISOString(),
+        },
+        createdAt: new Date(event.createdAt),
+      });
+    });
+
+    it("should create system log for task return from deferred", async () => {
+      const taskId = TaskId.generate();
+      const event = new TaskUndeferredEvent(taskId);
+
+      await handler.handle(event);
+
+      expect(mockDatabase.taskLogs.put).toHaveBeenCalledWith({
+        id: `task-undeferred-${event.aggregateId}-${event.createdAt}`,
+        taskId: taskId.value,
+        type: "SYSTEM",
+        message: "Task returned from deferred",
+        metadata: {
+          eventType: event.eventType,
         },
         createdAt: new Date(event.createdAt),
       });

--- a/src/features/tasks/presentation/components/task-card/TaskLogsModal.tsx
+++ b/src/features/tasks/presentation/components/task-card/TaskLogsModal.tsx
@@ -3,13 +3,25 @@ import { LogEntry } from "../../../../../shared/application/use-cases/GetTaskLog
 import { useTranslation } from "react-i18next";
 import { useCurrentTime } from "@/shared/presentation/contexts/CurrentTimeContext";
 import { formatTimeAgo } from "@/shared/utils/timeFormat";
-import { Settings, User, AlertTriangle, FileText, Pen } from "lucide-react";
+import {
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  FileText,
+  Pen,
+  PencilLine,
+  RotateCcw,
+  Settings,
+  Undo2,
+  User,
+} from "lucide-react";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "../../../../../shared/ui/dialog";
+import { DomainEventType } from "../../../../../shared/domain/types";
 
 interface TaskLogsModalProps {
   isOpen: boolean;
@@ -48,6 +60,65 @@ const getLogTypeColor = (type: "SYSTEM" | "USER" | "CONFLICT"): string => {
   }
 };
 
+const getLogEventKey = (log: LogEntry): string => {
+  const eventType = log.metadata?.eventType as DomainEventType | undefined;
+
+  if (eventType === DomainEventType.TASK_COMPLETED) {
+    return "completed";
+  }
+  if (eventType === DomainEventType.TASK_DEFERRED) {
+    return "deferred";
+  }
+  if (eventType === DomainEventType.TASK_UNDEFERRED) {
+    return "undeferred";
+  }
+  if (eventType === DomainEventType.TASK_TITLE_CHANGED) {
+    return "title_changed";
+  }
+  if (eventType === DomainEventType.TASK_CATEGORY_CHANGED) {
+    return "status_changed";
+  }
+  if (eventType === DomainEventType.TASK_COMPLETION_REVERTED) {
+    return "reverted";
+  }
+
+  if (log.type === "USER") {
+    return "user";
+  }
+  if (log.type === "CONFLICT") {
+    return "conflict";
+  }
+
+  return "system";
+};
+
+const getLogActionVisual = (
+  log: LogEntry
+): { Icon: React.ComponentType<{ className?: string }>; className: string } => {
+  const eventType = log.metadata?.eventType as DomainEventType | undefined;
+
+  if (eventType === DomainEventType.TASK_COMPLETED) {
+    return { Icon: CheckCircle2, className: "text-emerald-600" };
+  }
+  if (eventType === DomainEventType.TASK_DEFERRED) {
+    return { Icon: CalendarClock, className: "text-amber-600" };
+  }
+  if (eventType === DomainEventType.TASK_UNDEFERRED) {
+    return { Icon: Undo2, className: "text-indigo-600" };
+  }
+  if (eventType === DomainEventType.TASK_TITLE_CHANGED) {
+    return { Icon: PencilLine, className: "text-violet-600" };
+  }
+  if (eventType === DomainEventType.TASK_CATEGORY_CHANGED) {
+    return { Icon: RotateCcw, className: "text-sky-600" };
+  }
+
+  return {
+    Icon: getLogTypeIcon(log.type),
+    className: getLogTypeColor(log.type),
+  };
+};
+
 export const TaskLogsModal: React.FC<TaskLogsModalProps> = ({
   isOpen,
   onClose,
@@ -73,7 +144,6 @@ export const TaskLogsModal: React.FC<TaskLogsModalProps> = ({
       }, 100);
     }
   }, [isOpen]);
-
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -120,7 +190,8 @@ export const TaskLogsModal: React.FC<TaskLogsModalProps> = ({
               aria-label={t("taskCard.taskLogEntries")}
             >
               {taskLogs.map((log) => {
-                const LogIcon = getLogTypeIcon(log.type);
+                const { Icon, className } = getLogActionVisual(log);
+                const eventKey = getLogEventKey(log);
                 return (
                   <div
                     key={log.id}
@@ -128,29 +199,22 @@ export const TaskLogsModal: React.FC<TaskLogsModalProps> = ({
                     role="listitem"
                   >
                     <div className="flex items-start space-x-2">
-                      <LogIcon
-                        className={`w-3 h-3 mt-0.5 ${getLogTypeColor(
-                          log.type
-                        )}`}
+                      <Icon
+                        className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${className}`}
+                        data-testid={`log-action-icon-${eventKey}`}
                       />
                       <div className="flex-1 min-w-0">
                         <p className="text-gray-900 leading-relaxed whitespace-pre-wrap">
                           {log.message}
                         </p>
-                        <div className="flex items-center justify-between mt-1">
-                          <span
-                            className={`text-xs px-1 py-0.5 rounded font-medium ${
-                              log.type === "SYSTEM"
-                                ? "bg-blue-100 text-blue-800"
-                                : log.type === "USER"
-                                  ? "bg-green-100 text-green-800"
-                                  : "bg-red-100 text-red-800"
-                            }`}
-                          >
-                            {log.type}
-                          </span>
+                        <div className="flex items-center justify-end mt-1">
                           <span className="text-xs text-gray-500">
-                            {formatTimeAgo(log.createdAt, now, t, i18n.language)}
+                            {formatTimeAgo(
+                              log.createdAt,
+                              now,
+                              t,
+                              i18n.language
+                            )}
                           </span>
                         </div>
                       </div>

--- a/src/features/tasks/presentation/components/task-card/__tests__/TaskLogsModal.test.tsx
+++ b/src/features/tasks/presentation/components/task-card/__tests__/TaskLogsModal.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TaskLogsModal } from "../TaskLogsModal";
+import { DomainEventType } from "../../../../../../shared/domain/types";
+
+const baseProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  loadingLogs: false,
+  newLogText: "",
+  onNewLogTextChange: vi.fn(),
+  onNewLogKeyDown: vi.fn(),
+};
+
+describe("TaskLogsModal", () => {
+  it("shows action icons for key task history events", () => {
+    render(
+      <TaskLogsModal
+        {...baseProps}
+        taskLogs={[
+          {
+            id: 1,
+            taskId: "task-1",
+            type: "SYSTEM",
+            message: "Task completed in SIMPLE category",
+            metadata: { eventType: DomainEventType.TASK_COMPLETED },
+            createdAt: new Date("2026-04-25T12:00:00Z"),
+          },
+          {
+            id: 2,
+            taskId: "task-1",
+            type: "SYSTEM",
+            message: "Task deferred until 2026-04-30",
+            metadata: { eventType: DomainEventType.TASK_DEFERRED },
+            createdAt: new Date("2026-04-25T12:10:00Z"),
+          },
+          {
+            id: 3,
+            taskId: "task-1",
+            type: "SYSTEM",
+            message: "Task returned from deferred",
+            metadata: { eventType: DomainEventType.TASK_UNDEFERRED },
+            createdAt: new Date("2026-04-25T12:15:00Z"),
+          },
+          {
+            id: 4,
+            taskId: "task-1",
+            type: "SYSTEM",
+            message: 'Task title changed from "A" to "B"',
+            metadata: { eventType: DomainEventType.TASK_TITLE_CHANGED },
+            createdAt: new Date("2026-04-25T12:20:00Z"),
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId("log-action-icon-completed")).toBeInTheDocument();
+    expect(screen.getByTestId("log-action-icon-deferred")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("log-action-icon-undeferred")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("log-action-icon-title_changed")
+    ).toBeInTheDocument();
+  });
+
+  it("hides explicit log type labels", () => {
+    render(
+      <TaskLogsModal
+        {...baseProps}
+        taskLogs={[
+          {
+            id: 5,
+            taskId: "task-1",
+            type: "SYSTEM",
+            message: "Task completed in FOCUS category",
+            metadata: { eventType: DomainEventType.TASK_COMPLETED },
+            createdAt: new Date("2026-04-25T12:00:00Z"),
+          },
+        ]}
+      />
+    );
+
+    expect(screen.queryByText("SYSTEM")).not.toBeInTheDocument();
+    expect(screen.queryByText("USER")).not.toBeInTheDocument();
+    expect(screen.queryByText("CONFLICT")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Motivation
- Сделать историю активности чище и проще для быстрого сканирования, убрав визуальный шум и добавив понятные иконки действий. 
- Обеспечить сохранение всех ключевых событий по задачам: изменения статуса, перенос в отложенные, возврат из отложенных, изменение названия и выполнение. 
- Сделать записи истории идемпотентными и совместимыми с существующей событийной моделью (domain events → system logs). 

### Description
- Рефактор `TaskLogsModal` для отображения контекстных иконок действий вместо явных лейблов типов (`SYSTEM/USER/CONFLICT`) и упрощения строки записи; добавлены `getLogActionVisual` и `getLogEventKey` с отображением иконок из `lucide-react` (файл `src/features/tasks/presentation/components/task-card/TaskLogsModal.tsx`).
- Добавлена поддержка логирования отложенных событий в `TaskLogEventHandler`: теперь обрабатываются `TASK_DEFERRED` и `TASK_UNDEFERRED` и сохраняются системные записи с детальной metadata (файл `src/features/stats/application/event-handlers/TaskLogEventHandler.ts`).
- Расширены unit/UI тесты: добавлен тест `TaskLogsModal` для проверки иконок и отсутствия типовых лейблов и дополнены тесты обработчика событий для title-change, deferred/undeferred сценариев (файлы `src/features/tasks/presentation/components/task-card/__tests__/TaskLogsModal.test.tsx` и `src/features/stats/application/event-handlers/__tests__/TaskLogEventHandler.test.ts`).
- Мелкие правки форматирования и тестовых данных для согласованности с новым отображением (коммит в репозитории). 

### Testing
- Запуск юнитов и UI-тестов: `npm test -- src/features/stats/application/event-handlers/__tests__/TaskLogEventHandler.test.ts src/features/tasks/presentation/components/task-card/__tests__/TaskLogsModal.test.tsx` — все тесты прошли успешно (`14 passed`).
- Lint: `npm run lint -- <files>` не прошёл в этой среде из-за отсутствия конфигурации ESLint в корне репозитория, поэтому проверка статического анализа не выполнена (ошибка окружения).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8ee6869c8333a3708933c07cb135)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новые функции

* Добавлена полная поддержка отслеживания отложенных и восстановленных задач в истории.
* Обновлен интерфейс отображения истории задач: вместо общих меток теперь используются специальные иконки для каждого типа события (завершено, отложено, восстановлено, изменение названия).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->